### PR TITLE
Support LocalLLMClientLlama on Ubuntu

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,3 +57,32 @@ jobs:
         run: |
           cd Example
           xcodebuild build -project LocalLLMClientExample.xcodeproj -scheme LocalLLMClientExample -destination 'platform=macOS' CODE_SIGN_IDENTITY="-"
+
+  build-ubuntu-x86_64:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcurl4-openssl-dev
+
+      - name: Install Swift
+        shell: bash
+        run: |
+          curl -O "https://download.swift.org/swiftly/linux/swiftly-$(uname -m).tar.gz" && \
+          tar zxf "swiftly-$(uname -m).tar.gz" && \
+          ./swiftly init --assume-yes --no-modify-profile --skip-install --quiet-shell-followup && \
+          . ${SWIFTLY_HOME_DIR:-~/.local/share/swiftly}/env.sh && \
+          hash -r
+          swiftly install 6.1
+          echo "SWIFTLY_HOME_DIR=${SWIFTLY_HOME_DIR}" >>"${GITHUB_ENV}"
+          echo "SWIFTLY_BIN_DIR=${SWIFTLY_BIN_DIR}" >>"${GITHUB_ENV}"
+          echo "${SWIFTLY_BIN_DIR}" >>"${GITHUB_PATH}"
+
+      - name: Build package
+        run: swift build

--- a/Package.swift
+++ b/Package.swift
@@ -8,6 +8,7 @@ let llamaVersion = "b5486"
 
 var packageDependencies: [Package.Dependency] = [
     .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.4.0")),
+    .package(url: "https://github.com/johnmai-dev/Jinja", .upToNextMinor(from: "1.1.0")),
 ]
 
 #if os(iOS) || os(macOS)
@@ -30,6 +31,10 @@ packageProducts.append(contentsOf: [
     .library(name: "LocalLLMClientLlama", targets: ["LocalLLMClientLlama"]),
     .library(name: "LocalLLMClientMLX", targets: ["LocalLLMClientMLX"]),
     .library(name: "LocalLLMClientUtility", targets: ["LocalLLMClientUtility"])
+])
+#elseif os(Linux)
+packageProducts.append(contentsOf: [
+   .library(name: "LocalLLMClientLlama", targets: ["LocalLLMClientLlama"]),
 ])
 #endif
 
@@ -59,7 +64,7 @@ packageTargets.append(contentsOf: [
         dependencies: [
             "LocalLLMClient",
             "LocalLLMClientLlamaC",
-            .product(name: "Transformers", package: "swift-transformers"),
+            .product(name: "Jinja", package: "Jinja")
         ],
         resources: [.process("Resources")],
         swiftSettings: Context.environment["BUILD_DOCC"] == nil ? [] : [
@@ -105,6 +110,30 @@ packageTargets.append(contentsOf: [
             .product(name: "MLXLMCommon", package: "mlx-swift-examples"),
         ],
     )
+])
+#elseif os(Linux)
+packageTargets.append(contentsOf: [
+    .target(
+        name: "LocalLLMClientLlama",
+        dependencies: [
+            "LocalLLMClient",
+            "LocalLLMClientLlamaC",
+            .product(name: "Jinja", package: "Jinja")
+        ],
+        resources: [.process("Resources")]
+    ),
+    .target(
+        name: "LocalLLMClientLlamaC",
+        exclude: ["exclude"],
+        cSettings: [
+            .unsafeFlags(["-w"])
+        ],
+        linkerSettings: [
+            .unsafeFlags([
+                "-lggml-base", "-lggml-cpu", "-lggml-rpc", "-lggml", "-lllama", "-lmtmd_shared"
+            ])
+        ]
+    ),
 ])
 #endif
 

--- a/Sources/LocalLLMClientLlama/Batch.swift
+++ b/Sources/LocalLLMClientLlama/Batch.swift
@@ -1,7 +1,9 @@
 #if BUILD_DOCC
 @preconcurrency @_implementationOnly import llama
-#else
+#elseif canImport(llama)
 @preconcurrency private import llama
+#else
+@preconcurrency import LocalLLMClientLlamaC
 #endif
 
 package extension llama_batch {

--- a/Sources/LocalLLMClientLlama/Context.swift
+++ b/Sources/LocalLLMClientLlama/Context.swift
@@ -1,11 +1,12 @@
 #if BUILD_DOCC
 @preconcurrency @_implementationOnly import llama
-#else
+#elseif canImport(llama)
 @preconcurrency private import llama
+#else
+@preconcurrency import LocalLLMClientLlamaC
 #endif
 import Foundation
 import LocalLLMClient
-import os.lock
 
 public final class Context: @unchecked Sendable {
     let parameter: LlamaClient.Parameter

--- a/Sources/LocalLLMClientLlama/Decoder.swift
+++ b/Sources/LocalLLMClientLlama/Decoder.swift
@@ -1,7 +1,9 @@
 #if BUILD_DOCC
 @preconcurrency @_implementationOnly import llama
-#else
+#elseif canImport(llama)
 @preconcurrency private import llama
+#else
+@preconcurrency import LocalLLMClientLlamaC
 #endif
 import LocalLLMClient
 

--- a/Sources/LocalLLMClientLlama/Generator.swift
+++ b/Sources/LocalLLMClientLlama/Generator.swift
@@ -1,8 +1,10 @@
 import Foundation
 #if BUILD_DOCC
 @preconcurrency @_implementationOnly import llama
-#else
+#elseif canImport(llama)
 @preconcurrency private import llama
+#else
+@preconcurrency import LocalLLMClientLlamaC
 #endif
 import LocalLLMClient
 

--- a/Sources/LocalLLMClientLlama/Logger.swift
+++ b/Sources/LocalLLMClientLlama/Logger.swift
@@ -1,0 +1,33 @@
+#if canImport(OSLog)
+import OSLog
+#else
+import Foundation
+
+// Fallback for platforms without OSLog
+
+package struct Logger {
+    let subsystem: String
+    let category: String
+
+    func log(_ message: String) {
+        print("[\(subsystem).\(category)] \(message)")
+    }
+
+    func debug(_ message: String) {
+        print("[DEBUG] [\(subsystem).\(category)] \(message)")
+    }
+
+    func info(_ message: String) {
+        print("[INFO] [\(subsystem).\(category)] \(message)")
+    }
+
+    func warning(_ message: String) {
+        print("[WARNING] [\(subsystem).\(category)] \(message)")
+    }
+
+    func fault(_ message: String) {
+        print("[FAULT] [\(subsystem).\(category)] \(message)")
+    }
+}
+#endif
+

--- a/Sources/LocalLLMClientLlama/Sampler.swift
+++ b/Sources/LocalLLMClientLlama/Sampler.swift
@@ -1,7 +1,9 @@
 #if BUILD_DOCC
 @preconcurrency @_implementationOnly import llama
-#else
+#elseif canImport(llama)
 @preconcurrency private import llama
+#else
+@preconcurrency import LocalLLMClientLlamaC
 #endif
 import Foundation
 

--- a/Sources/LocalLLMClientLlama/Token.swift
+++ b/Sources/LocalLLMClientLlama/Token.swift
@@ -1,7 +1,9 @@
 #if BUILD_DOCC
 @preconcurrency @_implementationOnly import llama
-#else
+#elseif canImport(llama)
 @preconcurrency private import llama
+#else
+@preconcurrency import LocalLLMClientLlamaC
 #endif
 
 package extension [llama_token] {

--- a/Sources/LocalLLMClientLlama/Utility.swift
+++ b/Sources/LocalLLMClientLlama/Utility.swift
@@ -1,9 +1,13 @@
 #if BUILD_DOCC
 @preconcurrency @_implementationOnly import llama
-#else
+#elseif canImport(llama)
 @preconcurrency private import llama
+#else
+@preconcurrency import LocalLLMClientLlamaC
 #endif
+#if canImport(OSLog)
 import OSLog
+#endif
 
 // MARK: - Global State
 

--- a/Sources/LocalLLMClientLlama/stb_image.swift
+++ b/Sources/LocalLLMClientLlama/stb_image.swift
@@ -1,3 +1,4 @@
+#if canImport(CoreImage)
 // // Alternative to stb_image.h
 import Accelerate
 import CoreImage
@@ -73,3 +74,13 @@ package func imageDataToRGBBytes(
 
     return (result.baseAddress!, width, height)
 }
+#else
+import Foundation
+
+package func imageDataToRGBBytes(
+    imageData: Data
+) -> (bytes: UnsafeMutableRawPointer, width: Int, height: Int)? {
+    // TODO: Not supported in this environment currently.
+    return nil
+}
+#endif


### PR DESCRIPTION
- Support Linux builds using `#if` preprocessor directives.
- Add partial Linux support for LocalLLMClientLlama.
  - Image processing is not yet supported on Linux, but it's possible.
- Add a workflow for building on Ubuntu.

Note: 
MLX is currently not supported on Linux due to dependency limitations.
Running on Ubuntu (aarch64) might fail due to the current release artifacts of llama.cpp.