### PR TITLE
Fix iOS build errors and adjust -rpath linker setting for compatibility on macOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -57,7 +57,7 @@ packageTargets.append(contentsOf: [
             .product(name: "ArgumentParser", package: "swift-argument-parser"),
         ],
         linkerSettings: [
-            .unsafeFlags(["-rpath", "@executable_path"])
+            .unsafeFlags(["-Xlinker", "-rpath", "-Xlinker", "@executable_path"])
         ]
     ),
 

--- a/Sources/LocalLLMClient/LLMSession.swift
+++ b/Sources/LocalLLMClient/LLMSession.swift
@@ -91,6 +91,17 @@ extension LLMSession {
     }
 }
 
+extension FileDownloader.Source {
+    var id: String {
+        switch self {
+        case .huggingFace(let id, _):
+            return id
+        @unknown default:
+            fatalError("Unknown source type: \(self)")
+        }
+    }
+}
+
 public extension LLMSession {
     protocol Model: Sendable {
         var makeClient: @Sendable () async throws -> AnyLLMClient { get }
@@ -125,7 +136,7 @@ public extension LLMSession {
 #if os(iOS)
             downloader = FileDownloader(
                 source: source,
-                configuration: .background(withIdentifier: "localllmclient.llmsession.\(model.id)")
+                configuration: .background(withIdentifier: "localllmclient.llmsession.\(source.id)")
             )
 #else
             downloader = FileDownloader(source: source)


### PR DESCRIPTION
素敵なライブラリありがとうございます。

iOSをターゲットにコンパイルしたところエラーが出ましたので、一応直しました。
もっと適切な直し方があると思いますので、イシューとして見てもらえたら幸いです。

なぜかこちらの環境(macOS 15.5, Swift: swift-driver version: 1.120.5 Apple Swift version 6.1.2 (swiftlang-6.1.2.1.2 clang-1700.0.13.5))でPackage.swiftの"-rpath"部分でエラーが出たのでそれも直しました。