### PR TITLE
Support local models for LLMSession

### DIFF
--- a/Sources/LocalLLMClientCore/LLMSession.swift
+++ b/Sources/LocalLLMClientCore/LLMSession.swift
@@ -47,6 +47,11 @@ extension LLMSession {
     public convenience init(model: LLMSession.SystemModel, messages: [LLMInput.Message] = [], tools: [any LLMTool] = []) {
         self.init(model: model, messages: messages, tools: tools)
     }
+    
+    @_disfavoredOverload
+    public convenience init(model: LLMSession.LocalModel, messages: [LLMInput.Message] = [], tools: [any LLMTool] = []) {
+        self.init(model: model, messages: messages, tools: tools)
+    }
 }
 
 @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
@@ -291,6 +296,18 @@ public extension LLMSession {
 
         public func downloadModel(onProgress: @Sendable @escaping (Double) async -> Void = { _ in }) async throws {
             try await downloader.download(onProgress: onProgress)
+        }
+    }
+    
+    struct LocalModel: Model {
+        public let makeClient: @Sendable ([AnyLLMTool]) async throws -> AnyLLMClient
+        
+        package init(makeClient: @Sendable @escaping ([AnyLLMTool]) async throws -> AnyLLMClient) {
+            self.makeClient = makeClient
+        }
+        
+        public func prewarm() async throws {
+            // No prewarming needed for local models
         }
     }
 }

--- a/Sources/LocalLLMClientLlama/LLMSession+Llama.swift
+++ b/Sources/LocalLLMClientLlama/LLMSession+Llama.swift
@@ -35,4 +35,27 @@ public extension LLMSession.DownloadModel {
     }
 }
 
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+public extension LLMSession.LocalModel {
+    /// Create a llama.cpp model from local file paths
+    static func llama(
+        url: URL,
+        mmprojURL: URL? = nil,
+        parameter: LlamaClient.Parameter = .default
+    ) -> LLMSession.LocalModel {
+        return LLMSession.LocalModel(
+            makeClient: { tools in
+                try await AnyLLMClient(
+                    LocalLLMClient.llama(
+                        url: url,
+                        mmprojURL: mmprojURL,
+                        parameter: parameter,
+                        tools: tools.map { $0.underlyingTool }
+                    )
+                )
+            }
+        )
+    }
+}
+
 

--- a/Sources/LocalLLMClientMLX/LLMSession+MLX.swift
+++ b/Sources/LocalLLMClientMLX/LLMSession+MLX.swift
@@ -22,3 +22,20 @@ public extension LLMSession.DownloadModel {
         )
     }
 }
+
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+public extension LLMSession.LocalModel {
+    /// Create an MLX model from local file path
+    static func mlx(
+        url: URL,
+        parameter: MLXClient.Parameter = .default
+    ) -> LLMSession.LocalModel {
+        return LLMSession.LocalModel(
+            makeClient: { tools in
+                try await AnyLLMClient(
+                    LocalLLMClient.mlx(url: url, parameter: parameter, tools: tools.map { $0.underlyingTool })
+                )
+            }
+        )
+    }
+}

--- a/Tests/LocalLLMClientLlamaTests/LLMSessionLlamaTests.swift
+++ b/Tests/LocalLLMClientLlamaTests/LLMSessionLlamaTests.swift
@@ -3,6 +3,7 @@ import Foundation
 import LocalLLMClientCore
 import LocalLLMClientLlama
 import LocalLLMClientTestUtilities
+import LocalLLMClientUtility
 
 extension ModelTests {
     @Suite(.serialized, .timeLimit(.minutes(5)))
@@ -111,6 +112,32 @@ extension ModelTests {
             if let lastArgs = weatherTool.lastArguments {
                 #expect(lastArgs.location.lowercased().contains("paris"), "Tool should have been called with Paris as location")
             }
+        }
+        
+        @Test
+        func localModelLoading() async throws {
+            // First download the model to ensure we have a local copy
+            let info = LocalLLMClient.modelInfo(for: .general, modelSize: .light)
+            let downloader = FileDownloader(source: FileDownloader.Source.huggingFace(id: info.id, globs: [info.model]))
+            
+            // Download if not already downloaded
+            if !downloader.isDownloaded {
+                try await downloader.download()
+            }
+            
+            // Get the local path
+            let modelPath = downloader.destination.appending(component: info.model)
+            
+            // Create a session with the local model
+            let localModel = LLMSession.LocalModel.llama(url: modelPath)
+            let session = LLMSession(model: localModel)
+            
+            // Test that it works
+            let response = try await session.respond(to: "Hi, can you say hello?")
+            print("Local model response: \(response)")
+            
+            #expect(!response.isEmpty, "Local model should generate a response")
+            #expect(response.lowercased().contains("hello") || response.lowercased().contains("hi"), "Response should contain a greeting")
         }
     }
 }

--- a/Tests/LocalLLMClientLlamaTests/LLMSessionLlamaTests.swift
+++ b/Tests/LocalLLMClientLlamaTests/LLMSessionLlamaTests.swift
@@ -117,16 +117,10 @@ extension ModelTests {
         @Test
         func localModelLoading() async throws {
             // First download the model to ensure we have a local copy
+            // First download the model to ensure we have a local copy
             let info = LocalLLMClient.modelInfo(for: .general, modelSize: .light)
-            let downloader = FileDownloader(source: FileDownloader.Source.huggingFace(id: info.id, globs: [info.model]))
-            
-            // Download if not already downloaded
-            if !downloader.isDownloaded {
-                try await downloader.download()
-            }
-            
-            // Get the local path
-            let modelPath = downloader.destination.appending(component: info.model)
+            let destinationURL = try await LocalLLMClient.downloadModel(testType: .general, modelSize: .light)
+            let modelPath = destinationURL.appending(component: info.model)
             
             // Create a session with the local model
             let localModel = LLMSession.LocalModel.llama(url: modelPath)


### PR DESCRIPTION
* Add LocalModel in LLMSession to load local models.

## Copilot Summary
This pull request introduces support for loading and using local LLM models directly from file paths, expanding the flexibility of model management in the codebase. The main changes include the addition of the `LLMSession.LocalModel` type, convenience initializers for sessions using local models, and factory methods for creating local Llama and MLX models. A new test verifies the local model loading workflow.

### Local Model Support

* Added the `LLMSession.LocalModel` struct, enabling the creation and management of local models with a `makeClient` closure. This struct allows models to be loaded from local files without requiring downloads or prewarming.
* Introduced a new convenience initializer for `LLMSession` that accepts a `LocalModel`, making it easier to instantiate sessions with local models.

### Local Model Factories

* Added `llama(url:mmprojURL:parameter:)` factory method to `LLMSession.LocalModel`, allowing users to create a Llama model from a local file path.
* Added `mlx(url:parameter:)` factory method to `LLMSession.LocalModel`, enabling the creation of an MLX model from a local file path.

### Testing

* Added a new test, `localModelLoading`, to verify that a model can be downloaded, loaded from a local path, and used to generate a response, ensuring the new local model functionality works as expected.
* Included the necessary import for `LocalLLMClientUtility` in the test file to support the new test.