### PR TITLE
Fix build on Xcode 26

### DIFF
--- a/Sources/LocalLLMClientFoundationModels/FoundationModelsClient.swift
+++ b/Sources/LocalLLMClientFoundationModels/FoundationModelsClient.swift
@@ -44,8 +44,8 @@ public final actor FoundationModelsClient: LLMClient {
                     let session = LanguageModelSession(model: model, transcript: input.makeTranscript(generationOptions: generationOptions))
                     for try await text in session.streamResponse(to: input.makePrompt(), options: generationOptions) {
                         await pauseHandler.checkPauseState()
-                        continuation.yield(String(text[(position ?? text.startIndex)...]))
-                        position = text.endIndex
+                        continuation.yield(String(text.content[(position ?? text.content.startIndex)...]))
+                        position = text.content.endIndex
                     }
                 } catch {
                 }

--- a/Sources/LocalLLMClientFoundationModels/LLMSession+FoundationModels.swift
+++ b/Sources/LocalLLMClientFoundationModels/LLMSession+FoundationModels.swift
@@ -14,7 +14,7 @@ public extension LLMSession.Model {
     ) -> LLMSession.SystemModel {
         return LLMSession.SystemModel(
             prewarm: { LanguageModelSession(model: model).prewarm() },
-            makeClient: {
+            makeClient: { _ in 
                 try await AnyLLMClient(
                     LocalLLMClient.foundationModels(model: model, parameter: parameter)
                 )

--- a/Sources/LocalLLMClientMacrosPlugin/ToolArgumentEnumMacro.swift
+++ b/Sources/LocalLLMClientMacrosPlugin/ToolArgumentEnumMacro.swift
@@ -13,7 +13,7 @@ public struct ToolArgumentEnumMacro: ExtensionMacro {
         in context: some MacroExpansionContext
     ) throws -> [ExtensionDeclSyntax] {
         // Ensure the macro is applied to an enum
-        guard let enumDecl = declaration.as(EnumDeclSyntax.self) else {
+        guard declaration.as(EnumDeclSyntax.self) != nil else {
             context.diagnose(
                 Diagnostic(
                     node: node,
@@ -24,9 +24,10 @@ public struct ToolArgumentEnumMacro: ExtensionMacro {
         }
         
         // Create extension with the required conformances
+        // Use the 'type' parameter which contains the fully qualified type name
         let extensionDecl = try ExtensionDeclSyntax(
             """
-            extension \(enumDecl.name): Decodable, ToolArgumentType, CaseIterable {}
+            extension \(type): Decodable, ToolArgumentType, CaseIterable {}
             """
         )
         


### PR DESCRIPTION
https://github.com/tattn/LocalLLMClient/issues/51

- Fix build errors on Xcode 26

---
This pull request introduces several improvements and bug fixes to the local LLM client and macro plugin codebase. The most important changes address correct handling of streamed model responses, macro expansion robustness, and proper use of type information for generated code.

**Foundation Models Client Improvements:**

* Fixed streamed response handling in `FoundationModelsClient` by referencing the correct `text.content` property instead of the previous `text` string, ensuring accurate incremental output and position tracking.
* Updated the closure signature for `makeClient` in `LLMSession.Model` to accept an unused parameter, aligning with expected usage and improving API consistency.

**Macro Plugin Enhancements:**

* Improved macro expansion in `ToolArgumentEnumMacro` by removing unnecessary variable binding, making the check for enum declarations more robust and preventing potential runtime errors.
* Changed code generation in `ToolArgumentEnumMacro` to use the fully qualified type name from the `type` parameter, ensuring the generated extension applies to the correct type and supporting more complex enum declarations.