### PR TITLE
Improve performance of llama backend

### DIFF
--- a/Sources/LocalLLMCLI/BenchmarkCommand.swift
+++ b/Sources/LocalLLMCLI/BenchmarkCommand.swift
@@ -1,0 +1,396 @@
+// ## Basic benchmark (tests with a single prompt)
+// swift run -c release LocalLLMCLI benchmark --model ~/.localllmclient/huggingface/models/lmstudio-community/gemma-3-4B-it-qat-GGUF/gemma-3-4B-it-QAT-Q4_0.gguf --output ~/Desktop/results.json
+//
+// ## Basic benchmark with custom prompt
+// swift run LocalLLMCLI benchmark --model /path/to/model.gguf --prompt "Your custom prompt here"
+//
+// ## Context size benchmark (tests with different context sizes: 512, 1024, 2048)
+// swift run LocalLLMCLI benchmark --model /path/to/model.gguf --mode context
+//
+// ## Batch size benchmark (tests with different batch sizes: 1, 8, 32, 64)
+// swift run LocalLLMCLI benchmark --model /path/to/model.gguf --mode batch
+//
+// ## Run all benchmarks with custom prompt
+// swift run LocalLLMCLI benchmark --model /path/to/model.gguf --mode all --prompt "Custom prompt for all tests"
+//
+// ## Custom iterations (default is 3)
+// swift run LocalLLMCLI benchmark --model /path/to/model.gguf --mode basic --iterations 10
+//
+// ## Custom context sizes (comma-separated)
+// swift run LocalLLMCLI benchmark --model /path/to/model.gguf --mode context --context 256,512,1024,2048,4096
+//
+// ## Custom batch sizes (comma-separated)
+// swift run LocalLLMCLI benchmark --model /path/to/model.gguf --mode batch --batch 1,4,16,32,64,128
+//
+// ## Download model from HuggingFace and run benchmark
+// swift run LocalLLMCLI benchmark --model https://huggingface.co/lmstudio-community/gemma-3-4B-it-qat-GGUF/gemma-3-4B-it-QAT-Q4_0.gguf
+//
+// ## Verbose output for debugging
+// swift run LocalLLMCLI benchmark --model /path/to/model.gguf --mode basic --verbose
+//
+// MARK: - Benchmark Metrics
+//
+// The benchmark measures the following metrics:
+// - **First Token Latency (FTL)**: Time from request to first generated token (in seconds)
+// - **Prompt Decoding Time (PDT)**: Time to decode/process the input prompt (in seconds)
+// - **Tokens Per Second (TPS)**: Overall throughput of token generation (excludes prompt decoding time)
+// - **Total Tokens**: Number of tokens generated in each iteration
+//
+// Results are saved as JSON files in ./tmp/ directory by default, with the following structure:
+// - name: Benchmark test name
+// - metrics: Array of individual test runs
+// - summary: Aggregated statistics (average, min, max)
+// - timestamp: When the benchmark was run
+
+#if os(Linux)
+// Workaround: https://github.com/swiftlang/swift/issues/77866
+@preconcurrency import var Glibc.stdout
+#endif
+import ArgumentParser
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import LocalLLMClientCore
+import LocalLLMClientLlama
+#if canImport(LocalLLMClientMLX)
+import LocalLLMClientMLX
+#endif
+#if canImport(LocalLLMClientUtility)
+import LocalLLMClientUtility
+#endif
+
+struct BenchmarkCommand: AsyncParsableCommand {
+    nonisolated(unsafe) static var configuration = CommandConfiguration(
+        commandName: "benchmark",
+        abstract: "Run performance benchmarks on a local LLM"
+    )
+
+    @Option(name: [.short, .long], help: "Path to the model file")
+    var model: String = ""
+
+    @Option(name: [.customLong("mode")], help: "Benchmark mode: basic, context, batch, all")
+    var mode: String = "basic"
+
+    @Option(name: [.short, .long], help: "Number of iterations per benchmark")
+    var iterations: Int = 3
+
+    @Option(name: [.short, .customLong("context")], help: "Context size for benchmarks (comma-separated for multiple)")
+    var contextSizes: String = "512,1024,2048"
+
+    @Option(name: [.short, .customLong("batch")], help: "Batch sizes for benchmarks (comma-separated for multiple)")
+    var batchSizes: String = "1,8,32,64"
+
+    @Option(name: [.customShort("o"), .long], help: "Output file for benchmark results (JSON)")
+    var output: String?
+
+    @Option(name: [.customShort("p"), .long], help: "Custom prompt for benchmarking (overrides default prompt)")
+    var prompt: String?
+
+    @Flag(name: [.customShort("v"), .long], help: "Show verbose output")
+    var verbose: Bool = false
+
+    func run() async throws {
+        print("🚀 Starting benchmark for model: \(model)")
+        print("Mode: \(mode), Iterations: \(iterations)")
+        print("")
+
+        var allResults: [BenchmarkResult] = []
+
+        switch mode.lowercased() {
+        case "basic":
+            allResults = try await runBasicBenchmark()
+        case "context":
+            allResults = try await runContextBenchmark()
+        case "batch":
+            allResults = try await runBatchBenchmark()
+        case "all":
+            allResults += try await runBasicBenchmark()
+            allResults += try await runContextBenchmark()
+            allResults += try await runBatchBenchmark()
+        default:
+            throw LocalLLMCommandError.invalidModel("Unknown benchmark mode: \(mode). Use: basic, context, batch, or all")
+        }
+
+        // Print summary
+        printSummary(allResults)
+
+        // Save results
+        if let output = output {
+            try saveResults(allResults, to: output)
+        } else {
+            try saveResults(allResults)
+        }
+    }
+
+    private func runBasicBenchmark() async throws -> [BenchmarkResult] {
+        print("📊 Running basic benchmark...")
+        let benchmarkPrompt = prompt ?? "Please write the opening of a short story set in a future Tokyo, with a cat as the main character. Make it cyberpunk-style, include vivid emotional descriptions, and craft the story so that the reader cannot predict what will happen next."
+
+        print("  Testing with prompt: \"\(String(benchmarkPrompt.prefix(50)))...\"")
+        let metrics = try await runSingleBenchmark(prompt: benchmarkPrompt, iterations: iterations)
+        
+        return [BenchmarkResult(
+            name: "Basic benchmark",
+            metrics: metrics,
+            summary: calculateSummary(metrics),
+            timestamp: Date()
+        )]
+    }
+
+    private func runContextBenchmark() async throws -> [BenchmarkResult] {
+        print("📊 Running context size benchmark...")
+        let contexts = contextSizes.split(separator: ",").compactMap { Int($0.trimmingCharacters(in: .whitespaces)) }
+        let benchmarkPrompt = prompt ?? "Explain quantum computing in detail."
+        var results: [BenchmarkResult] = []
+
+        for context in contexts {
+            print("  Testing context size: \(context)")
+            let metrics = try await runSingleBenchmark(
+                prompt: benchmarkPrompt,
+                iterations: iterations,
+                context: context
+            )
+            results.append(BenchmarkResult(
+                name: "Context \(context)",
+                metrics: metrics,
+                summary: calculateSummary(metrics),
+                timestamp: Date()
+            ))
+        }
+        return results
+    }
+
+    private func runBatchBenchmark() async throws -> [BenchmarkResult] {
+        print("📊 Running batch size benchmark...")
+        let batches = batchSizes.split(separator: ",").compactMap { Int($0.trimmingCharacters(in: .whitespaces)) }
+        let benchmarkPrompt = prompt ?? "Explain the theory of relativity."
+        var results: [BenchmarkResult] = []
+
+        for batch in batches {
+            print("  Testing batch size: \(batch)")
+            let metrics = try await runSingleBenchmark(
+                prompt: benchmarkPrompt,
+                iterations: iterations,
+                batch: batch
+            )
+            results.append(BenchmarkResult(
+                name: "Batch \(batch)",
+                metrics: metrics,
+                summary: calculateSummary(metrics),
+                timestamp: Date()
+            ))
+        }
+        return results
+    }
+
+    private func runSingleBenchmark(
+        prompt: String,
+        iterations: Int,
+        context: Int? = nil,
+        batch: Int? = nil
+    ) async throws -> [BenchmarkMetrics] {
+        var parameter = LlamaClient.Parameter(
+            temperature: 0.7,
+            topP: 0.9,
+            options: .init(verbose: verbose)
+        )
+
+        if let context = context {
+            parameter.context = context
+        }
+        if let batch = batch {
+            parameter.batch = batch
+        }
+
+        let modelURL = try await getModel()
+        let client = try await LocalLLMClient.llama(
+            url: modelURL,
+            parameter: parameter
+        )
+
+        var metrics: [BenchmarkMetrics] = []
+
+        for i in 1...iterations {
+            if verbose {
+                print("    Iteration \(i)/\(iterations)...")
+            }
+
+            var firstTokenLatency: TimeInterval = 0
+            var promptDecodingTime: TimeInterval = 0
+            var tokensGenerated = 0
+            var isFirstToken = true
+            let start = Date()
+
+            let generator = try await client.textStream(from: prompt)
+            promptDecodingTime = Date().timeIntervalSince(start)
+            
+            let generationStart = Date()
+            for try await _ in generator {
+                if isFirstToken {
+                    firstTokenLatency = Date().timeIntervalSince(start)
+                    isFirstToken = false
+                }
+                tokensGenerated += 1
+            }
+
+            let generationTime = Date().timeIntervalSince(generationStart)
+            let totalTime = Date().timeIntervalSince(start)
+
+            metrics.append(BenchmarkMetrics(
+                firstTokenLatency: firstTokenLatency,
+                promptDecodingTime: promptDecodingTime,
+                tokensPerSecond: Double(tokensGenerated) / generationTime,
+                totalTokens: tokensGenerated,
+                totalTime: totalTime
+            ))
+        }
+
+        return metrics
+    }
+
+    private func calculateSummary(_ metrics: [BenchmarkMetrics]) -> BenchmarkResult.Summary {
+        let tps = metrics.map(\.tokensPerSecond)
+        let ftl = metrics.map(\.firstTokenLatency)
+        let pdt = metrics.map(\.promptDecodingTime)
+        let tt = metrics.map(\.totalTime)
+
+        return BenchmarkResult.Summary(
+            avgTokensPerSecond: tps.reduce(0, +) / Double(tps.count),
+            avgFirstTokenLatency: ftl.reduce(0, +) / Double(ftl.count),
+            minFirstTokenLatency: ftl.min() ?? 0,
+            maxFirstTokenLatency: ftl.max() ?? 0,
+            avgPromptDecodingTime: pdt.reduce(0, +) / Double(pdt.count),
+            minPromptDecodingTime: pdt.min() ?? 0,
+            maxPromptDecodingTime: pdt.max() ?? 0,
+            avgTotalTime: tt.reduce(0, +) / Double(tt.count),
+            minTotalTime: tt.min() ?? 0,
+            maxTotalTime: tt.max() ?? 0
+        )
+    }
+
+    private func printSummary(_ results: [BenchmarkResult]) {
+        print("\n📈 Benchmark Results Summary:")
+        print(String(repeating: "=", count: 80))
+        
+        // Header
+        let header = "\(padString("Test", to: 20)) \(padString("TPS", to: 8)) \(padString("FTL(s)", to: 8)) \(padString("PDT(s)", to: 8)) \(padString("Total(s)", to: 10))"
+        print(header)
+        print(String(repeating: "-", count: 90))
+        
+        // Results
+        for result in results {
+            let name = padString(result.name, to: 20)
+            let tps = padString(String(format: "%.1f", result.summary.avgTokensPerSecond), to: 8)
+            let ftl = padString(String(format: "%.3f", result.summary.avgFirstTokenLatency), to: 8)
+            let pdt = padString(String(format: "%.3f", result.summary.avgPromptDecodingTime), to: 8)
+            let tt = padString(String(format: "%.3f", result.summary.avgTotalTime), to: 10)
+            print("\(name) \(tps) \(ftl) \(pdt) \(tt)")
+            
+            if verbose {
+                let ftlMin = String(format: "%.3f", result.summary.minFirstTokenLatency)
+                let ftlMax = String(format: "%.3f", result.summary.maxFirstTokenLatency)
+                let pdtMin = String(format: "%.3f", result.summary.minPromptDecodingTime)
+                let pdtMax = String(format: "%.3f", result.summary.maxPromptDecodingTime)
+                let ttMin = String(format: "%.3f", result.summary.minTotalTime)
+                let ttMax = String(format: "%.3f", result.summary.maxTotalTime)
+                print("  FTL range: \(ftlMin) - \(ftlMax), PDT range: \(pdtMin) - \(pdtMax), Total range: \(ttMin) - \(ttMax)")
+            }
+        }
+        
+        print(String(repeating: "=", count: 90))
+        print("TPS: Tokens Per Second, FTL: First Token Latency, PDT: Prompt Decoding Time, Total: Total Processing Time")
+    }
+    
+    private func padString(_ str: String, to length: Int) -> String {
+        if str.count >= length {
+            return String(str.prefix(length))
+        }
+        return str + String(repeating: " ", count: length - str.count)
+    }
+
+    private func saveResults(_ results: [BenchmarkResult], to filename: String? = nil) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+
+        let jsonData = try encoder.encode(results)
+
+        let tmpDir = URL(fileURLWithPath: "./tmp")
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+
+        let fileURL: URL
+        if let filename = filename {
+            fileURL = URL(fileURLWithPath: filename)
+        } else {
+            let formatter = DateFormatter()
+            formatter.dateFormat = "yyyyMMdd_HHmmss"
+            let filename = "benchmark_\(formatter.string(from: Date())).json"
+            fileURL = tmpDir.appendingPathComponent(filename)
+        }
+
+        try jsonData.write(to: fileURL)
+        print("\n💾 Results saved to: \(fileURL.path)")
+    }
+
+    private func getModel() async throws -> URL {
+        if model.hasPrefix("/") {
+            return URL(filePath: model)
+        } else if model.hasPrefix("https://"), let url = URL(string: model) {
+            return try await downloadModel(from: url)
+        } else if model.isEmpty {
+            throw LocalLLMCommandError.invalidModel("Error: Missing expected argument '--model <model>'")
+        } else {
+            throw LocalLLMCommandError.invalidModel(model)
+        }
+    }
+
+    private func downloadModel(from url: URL) async throws -> URL {
+        #if canImport(LocalLLMClientUtility)
+        print("Downloading model from Hugging Face: \(model)")
+
+        let downloader = FileDownloader(source: .huggingFace(
+            id: url.pathComponents[1...2].joined(separator: "/"),
+            globs: .init(["*\(url.lastPathComponent)"])
+        ))
+        try await downloader.download { progress in
+            if verbose {
+                print("Downloading model: \(progress)")
+            }
+        }
+        return downloader.destination.appendingPathComponent(url.lastPathComponent)
+        #else
+        throw LocalLLMCommandError.invalidModel("Downloading models is not supported on this platform.")
+        #endif
+    }
+}
+
+// Benchmark data structures
+struct BenchmarkMetrics: Codable {
+    let firstTokenLatency: TimeInterval
+    let promptDecodingTime: TimeInterval
+    let tokensPerSecond: Double
+    let totalTokens: Int
+    let totalTime: TimeInterval
+}
+
+struct BenchmarkResult: Codable {
+    let name: String
+    let metrics: [BenchmarkMetrics]
+    let summary: Summary
+    let timestamp: Date
+
+    struct Summary: Codable {
+        let avgTokensPerSecond: Double
+        let avgFirstTokenLatency: Double
+        let minFirstTokenLatency: Double
+        let maxFirstTokenLatency: Double
+        let avgPromptDecodingTime: Double
+        let minPromptDecodingTime: Double
+        let maxPromptDecodingTime: Double
+        let avgTotalTime: Double
+        let minTotalTime: Double
+        let maxTotalTime: Double
+    }
+}
+

--- a/Sources/LocalLLMCLI/Common.swift
+++ b/Sources/LocalLLMCLI/Common.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(LocalLLMClientUtility)
+import LocalLLMClientUtility
+#endif
 
 enum Backend: String, CaseIterable {
     case llama
@@ -8,4 +11,59 @@ enum Backend: String, CaseIterable {
 
 enum LocalLLMCommandError: Error {
     case invalidModel(String)
+}
+
+// MARK: - Model Loading Utilities
+
+struct ModelLoader {
+    let verbose: Bool
+    
+    init(verbose: Bool = false) {
+        self.verbose = verbose
+    }
+    
+    func getModel(for model: String, backend: Backend) async throws -> URL {
+        if model.hasPrefix("/") {
+            return URL(filePath: model)
+        } else if model.hasPrefix("https://"), let url = URL(string: model) {
+            return try await downloadModel(from: url, backend: backend)
+        } else if model.isEmpty {
+            throw LocalLLMCommandError.invalidModel("Error: Missing expected argument '--model <model>'")
+        } else {
+            throw LocalLLMCommandError.invalidModel(model)
+        }
+    }
+    
+    private func downloadModel(from url: URL, backend: Backend) async throws -> URL {
+        #if canImport(LocalLLMClientUtility)
+        log("Downloading model from Hugging Face: \(url)")
+        
+        let globs: Globs = switch backend {
+        case .llama: .init(["*\(url.lastPathComponent)"])
+        case .mlx: .mlx
+        case .foundationModels: []
+        }
+        
+        let downloader = FileDownloader(source: .huggingFace(
+            id: url.pathComponents[1...2].joined(separator: "/"),
+            globs: globs
+        ))
+        try await downloader.download { progress in
+            log("Downloading model: \(progress)")
+        }
+        return switch backend {
+        case .llama: downloader.destination.appendingPathComponent(url.lastPathComponent)
+        case .mlx: downloader.destination
+        case .foundationModels: throw LocalLLMCommandError.invalidModel("Model downloading is not applicable for the FoundationModels backend.")
+        }
+        #else
+        throw LocalLLMCommandError.invalidModel("Downloading models is not supported on this platform.")
+        #endif
+    }
+    
+    private func log(_ message: String) {
+        if verbose {
+            print(message)
+        }
+    }
 }

--- a/Sources/LocalLLMCLI/Common.swift
+++ b/Sources/LocalLLMCLI/Common.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+enum Backend: String, CaseIterable {
+    case llama
+    case mlx
+    case foundationModels = "foundation-models"
+}
+
+enum LocalLLMCommandError: Error {
+    case invalidModel(String)
+}

--- a/Sources/LocalLLMCLI/RunCommand.swift
+++ b/Sources/LocalLLMCLI/RunCommand.swift
@@ -1,0 +1,166 @@
+#if os(Linux)
+// Workaround: https://github.com/swiftlang/swift/issues/77866
+@preconcurrency import var Glibc.stdout
+#endif
+import ArgumentParser
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import LocalLLMClientCore
+import LocalLLMClientLlama
+#if canImport(LocalLLMClientMLX)
+import LocalLLMClientMLX
+#endif
+#if canImport(LocalLLMClientFoundationModels)
+import LocalLLMClientFoundationModels
+#endif
+#if canImport(LocalLLMClientUtility)
+import LocalLLMClientUtility
+#endif
+
+struct RunCommand: AsyncParsableCommand {
+    nonisolated(unsafe) static var configuration = CommandConfiguration(
+        commandName: "run",
+        abstract: "Run a single prompt through a local LLM"
+    )
+
+    @Option(name: [.short, .long], help: "Path to the model file")
+    var model: String = ""
+
+    @Option(name: [.short, .long], help: "Backend to use: \(Backend.allCases.map(\.rawValue).joined(separator: ", "))")
+    var backend: String = Backend.llama.rawValue
+
+    @Option(name: [.short, .long], help: "Temperature for sampling")
+    var temperature: Float = 0.8
+
+    @Option(name: [.customShort("p"), .long], help: "Top-p for sampling")
+    var topP: Float = 0.9
+
+    @Option(name: [.customShort("k"), .long], help: "Top-k for sampling")
+    var topK: Int = 40
+
+    @Option(name: [.long], help: "Path to the mmproj")
+    var mmproj: String?
+    @Option(name: [.customLong("image")], help: "Path to the image file")
+    var imageURL: String?
+
+    @Flag(name: [.customShort("v"), .long], help: "Show verbose output")
+    var verbose: Bool = false
+
+    @Argument(help: "The prompt to send to the model")
+    var prompt: String
+
+    func run() async throws {
+        let backend = Backend(rawValue: backend) ?? .llama
+        log("Loading model from: \(model) with backend: \(backend.rawValue)")
+
+        // Initialize client
+        let client: any LLMClient
+        switch backend {
+        case .llama:
+            client = try await LocalLLMClient.llama(
+                url: getModel(for: model, backend: backend),
+                mmprojURL: mmproj.asyncMap { try await getModel(for: $0, backend: backend) },
+                parameter: .init(
+                    temperature: temperature,
+                    topK: topK,
+                    topP: topP,
+                    options: .init(verbose: verbose)
+                )
+            )
+        case .mlx:
+#if canImport(LocalLLMClientMLX)
+            client = try await LocalLLMClient.mlx(
+                url: getModel(for: model, backend: backend),
+                parameter: .init(
+                    temperature: temperature,
+                    topP: topP,
+                )
+            )
+#else
+            throw LocalLLMCommandError.invalidModel("MLX backend is not supported on this platform.")
+#endif
+        case .foundationModels:
+#if canImport(FoundationModels)
+            if #available(macOS 26.0, iOS 26.0, *) {
+                client = try await LocalLLMClient.foundationModels(
+                    parameter: .init(
+                        temperature: Double(temperature)
+                    )
+                )
+            } else {
+                throw LocalLLMCommandError.invalidModel("FoundationModels backend is not supported on this environment.")
+            }
+#else
+            throw LocalLLMCommandError.invalidModel("FoundationModels backend is not supported on this environment.")
+#endif
+        }
+
+        var attachments: [LLMAttachment] = []
+        if let imageURL {
+            attachments.append(.image(LLMInputImage(data: try Data(contentsOf: URL(filePath: imageURL)))!))
+        }
+
+        log("Generating response for prompt: \"\(prompt)\"")
+        log("---")
+
+        let input = LLMInput(
+            .chat([.user(prompt, attachments: attachments)]),
+        )
+
+        // Generate response
+        for try await token in try await client.textStream(from: input) {
+            print(token, terminator: "")
+            fflush(stdout)
+        }
+
+        log("\n---")
+        log("Generation complete.")
+    }
+
+    private func getModel(for model: String, backend: Backend) async throws -> URL {
+        return if model.hasPrefix("/") {
+            URL(filePath: model)
+        } else if model.hasPrefix("https://"), let url = URL(string: model) {
+            try await downloadModel(from: url, backend: backend)
+        } else if model.isEmpty {
+            throw LocalLLMCommandError.invalidModel("Error: Missing expected argument '--model <model>'")
+        } else {
+            throw LocalLLMCommandError.invalidModel(model)
+        }
+    }
+
+    private func downloadModel(from url: URL, backend: Backend) async throws -> URL {
+        #if canImport(LocalLLMClientUtility)
+        log("Downloading model from Hugging Face: \(model)")
+
+        let globs: Globs = switch backend {
+        case .llama: .init(["*\(url.lastPathComponent)"])
+        case .mlx: .mlx
+        case .foundationModels: []
+        }
+
+        let downloader = FileDownloader(source: .huggingFace(
+            id: url.pathComponents[1...2].joined(separator: "/"),
+            globs: globs
+        ))
+        try await downloader.download { progress in
+            log("Downloading model: \(progress)")
+        }
+        return switch backend {
+        case .llama: downloader.destination.appendingPathComponent(url.lastPathComponent)
+        case .mlx: downloader.destination
+        case .foundationModels: throw LocalLLMCommandError.invalidModel("Model downloading is not applicable for the FoundationModels backend.")
+        }
+        #else
+        throw LocalLLMCommandError.invalidModel("Downloading models is not supported on this platform.")
+        #endif
+    }
+
+    private func log(_ message: String) {
+        if verbose {
+            print(message)
+        }
+    }
+}

--- a/Sources/LocalLLMCLI/command.swift
+++ b/Sources/LocalLLMCLI/command.swift
@@ -1,23 +1,4 @@
-#if os(Linux)
-// Workaround: https://github.com/swiftlang/swift/issues/77866
-@preconcurrency import var Glibc.stdout
-#endif
 import ArgumentParser
-import Foundation
-#if canImport(FoundationNetworking)
-import FoundationNetworking
-#endif
-import LocalLLMClientCore
-import LocalLLMClientLlama
-#if canImport(LocalLLMClientMLX)
-import LocalLLMClientMLX
-#endif
-#if canImport(LocalLLMClientFoundationModels)
-import LocalLLMClientFoundationModels
-#endif
-#if canImport(LocalLLMClientUtility)
-import LocalLLMClientUtility
-#endif
 
 @main
 struct LocalLLMCommand: AsyncParsableCommand {
@@ -26,155 +7,16 @@ struct LocalLLMCommand: AsyncParsableCommand {
         abstract: "A command line tool for interacting with local LLMs",
         discussion: """
             Run LLM models directly from your command line.
-            """
+            
+            Examples:
+              # Run a single prompt
+              localllm run --model /path/to/model.gguf "What is 2+2?"
+              
+              # Run benchmarks
+              localllm benchmark --model /path/to/model.gguf --mode basic
+              localllm benchmark --model /path/to/model.gguf --mode context --iterations 5
+            """,
+        subcommands: [RunCommand.self, BenchmarkCommand.self],
+        defaultSubcommand: RunCommand.self
     )
-
-    @Option(name: [.short, .long], help: "Path to the model file")
-    var model: String = ""
-
-    @Option(name: [.short, .long], help: "Backend to use: \(Backend.allCases.map(\.rawValue).joined(separator: ", "))")
-    var backend: String = Backend.llama.rawValue
-
-    @Option(name: [.short, .long], help: "Temperature for sampling")
-    var temperature: Float = 0.8
-
-    @Option(name: [.customShort("p"), .long], help: "Top-p for sampling")
-    var topP: Float = 0.9
-
-    @Option(name: [.customShort("k"), .long], help: "Top-k for sampling")
-    var topK: Int = 40
-
-    @Option(name: [.long], help: "Path to the mmproj")
-    var mmproj: String?
-    @Option(name: [.customLong("image")], help: "Path to the image file")
-    var imageURL: String?
-
-    @Flag(name: [.customShort("v"), .long], help: "Show verbose output")
-    var verbose: Bool = false
-
-    @Argument(help: "The prompt to send to the model")
-    var prompt: String
-
-    enum Backend: String, CaseIterable {
-        case llama
-        case mlx
-        case foundationModels = "foundation-models"
-    }
-
-    func run() async throws {
-        let backend = Backend(rawValue: backend) ?? .llama
-        log("Loading model from: \(model) with backend: \(backend.rawValue)")
-
-        // Initialize client
-        let client: any LLMClient
-        switch backend {
-        case .llama:
-            client = try await LocalLLMClient.llama(
-                url: getModel(for: model, backend: backend),
-                mmprojURL: mmproj.asyncMap { try await getModel(for: $0, backend: backend) },
-                parameter: .init(
-                    temperature: temperature,
-                    topK: topK,
-                    topP: topP,
-                    options: .init(verbose: verbose)
-                )
-            )
-        case .mlx:
-#if canImport(LocalLLMClientMLX)
-            client = try await LocalLLMClient.mlx(
-                url: getModel(for: model, backend: backend),
-                parameter: .init(
-                    temperature: temperature,
-                    topP: topP,
-                )
-            )
-#else
-            throw LocalLLMCommandError.invalidModel("MLX backend is not supported on this platform.")
-#endif
-        case .foundationModels:
-#if canImport(FoundationModels)
-            if #available(macOS 26.0, iOS 26.0, *) {
-                client = try await LocalLLMClient.foundationModels(
-                    parameter: .init(
-                        temperature: Double(temperature)
-                    )
-                )
-            } else {
-                throw LocalLLMCommandError.invalidModel("FoundationModels backend is not supported on this environment.")
-            }
-#else
-            throw LocalLLMCommandError.invalidModel("FoundationModels backend is not supported on this environment.")
-#endif
-        }
-
-        var attachments: [LLMAttachment] = []
-        if let imageURL {
-            attachments.append(.image(LLMInputImage(data: try Data(contentsOf: URL(filePath: imageURL)))!))
-        }
-
-        log("Generating response for prompt: \"\(prompt)\"")
-        log("---")
-
-        let input = LLMInput(
-            .chat([.user(prompt, attachments: attachments)]),
-        )
-
-        // Generate response
-        for try await token in try await client.textStream(from: input) {
-            print(token, terminator: "")
-            fflush(stdout)
-        }
-
-        log("\n---")
-        log("Generation complete.")
-    }
-
-    private func getModel(for model: String, backend: Backend) async throws -> URL {
-        return if model.hasPrefix("/") {
-            URL(filePath: model)
-        } else if model.hasPrefix("https://"), let url = URL(string: model) {
-            try await downloadModel(from: url, backend: backend)
-        } else if model.isEmpty {
-            throw LocalLLMCommandError.invalidModel("Error: Missing expected argument '--model <model>'")
-        } else {
-            throw LocalLLMCommandError.invalidModel(model)
-        }
-    }
-
-    private func downloadModel(from url: URL, backend: Backend) async throws -> URL {
-        #if canImport(LocalLLMClientUtility)
-        log("Downloading model from Hugging Face: \(model)")
-
-        let globs: Globs = switch backend {
-        case .llama: .init(["*\(url.lastPathComponent)"])
-        case .mlx: .mlx
-        case .foundationModels: []
-        }
-
-        let downloader = FileDownloader(source: .huggingFace(
-            id: url.pathComponents[1...2].joined(separator: "/"),
-            globs: globs
-        ))
-        try await downloader.download { progress in
-            log("Downloading model: \(progress)")
-        }
-        return switch backend {
-        case .llama: downloader.destination.appendingPathComponent(url.lastPathComponent)
-        case .mlx: downloader.destination
-        case .foundationModels: throw LocalLLMCommandError.invalidModel("Model downloading is not applicable for the FoundationModels backend.")
-        }
-        #else
-        throw LocalLLMCommandError.invalidModel("Downloading models is not supported on this platform.")
-        #endif
-    }
-
-    private func log(_ message: String) {
-        if verbose {
-            print(message)
-        }
-    }
-}
-
-enum LocalLLMCommandError: Error {
-    case invalidModel(String)
 }

--- a/Sources/LocalLLMClientLlama/Generator.swift
+++ b/Sources/LocalLLMClientLlama/Generator.swift
@@ -47,7 +47,7 @@ public struct TokenGenerator: AsyncIteratorProtocol {
                 return nil
             } else {
                 let newToken = makeString() ?? ""
-                temporaryInvalidCharacters.removeAll()
+                temporaryInvalidCharacters.removeAll(keepingCapacity: true)
                 return newToken
             }
         }
@@ -56,18 +56,18 @@ public struct TokenGenerator: AsyncIteratorProtocol {
 
         let newToken: String
         if let token = makeString() {
-            temporaryInvalidCharacters.removeAll()
+            temporaryInvalidCharacters.removeAll(keepingCapacity: true)
             newToken = token
         } else if (1 ..< temporaryInvalidCharacters.count).contains(where: { String(utf8String: Array(temporaryInvalidCharacters.suffix($0)) + [0]) != nil }) {
             let token = makeString() ?? ""
-            temporaryInvalidCharacters.removeAll()
+            temporaryInvalidCharacters.removeAll(keepingCapacity: true)
             newToken = token
         } else {
             newToken = ""
         }
 
         if context.extraEOSTokens.contains(newToken) {
-            temporaryInvalidCharacters.removeAll()
+            temporaryInvalidCharacters.removeAll(keepingCapacity: true)
             updatePromptCache()
             return nil
         }

--- a/Tests/LocalLLMClientLlamaTests/MessageProcessorTests.swift
+++ b/Tests/LocalLLMClientLlamaTests/MessageProcessorTests.swift
@@ -138,7 +138,7 @@ struct MessageProcessorTests {
 }
 
 private extension LLMInputImage {
-    nonisolated(unsafe) static let testImage = LLMInputImage()
+    static let testImage = LLMInputImage()
 }
 
 private extension LLMAttachment {

--- a/Tests/LocalLLMClientLlamaTests/MessageProcessorTests.swift
+++ b/Tests/LocalLLMClientLlamaTests/MessageProcessorTests.swift
@@ -138,7 +138,11 @@ struct MessageProcessorTests {
 }
 
 private extension LLMInputImage {
+#if swift(>=6.2)
     static let testImage = LLMInputImage()
+#else
+    nonisolated(unsafe) static let testImage = LLMInputImage()
+#endif
 }
 
 private extension LLMAttachment {


### PR DESCRIPTION
- Improve performance of llama backend

| Name | Old | New |
|------|-----|-----|
| **avgFirstTokenLatency** | 0.1112896601 | 0.1015799840 |
| **avgPromptDecodingTime** | 0.0043340127 | 0.0055063168 |
| **avgTokensPerSecond** | 28.2394521 | 67.7651768 |
| **avgTotalTime** | 71.5933350 | 29.5615257 |
| **maxFirstTokenLatency** | 0.1292719841 | 0.1044499874 |
| **maxPromptDecodingTime** | 0.0051440001 | 0.0056489706 |
| **maxTotalTime** | 82.4180670 | 30.7829370 |
| **minFirstTokenLatency** | 0.0991740227 | 0.0972169638 |
| **minPromptDecodingTime** | 0.0037740469 | 0.0054199696 |
| **minTotalTime** | 65.5089631 | 28.0940959 |

<details>
<summary>raw</summary>

<table style="width:100%; border-collapse:collapse;">
  <tr>
    <th style="text-align:left; width:50%;">OLD</th>
    <th style="text-align:left; width:50%;">NEW</th>
  </tr>
  <tr>
    <td style="vertical-align:top; padding:8px;">
<pre><code class="language-json">[
  {
    "metrics" : [
      {
        "firstTokenLatency" : 0.1292719841003418,
        "promptDecodingTime" : 0.005144000053405762,
        "tokensPerSecond" : 29.918696983247298,
        "totalTime" : 66.85297501087189,
        "totalTokens" : 2000
      },
      {
        "firstTokenLatency" : 0.09917402267456055,
        "promptDecodingTime" : 0.0037740468978881836,
        "tokensPerSecond" : 30.531932834965623,
        "totalTime" : 65.50896310806274,
        "totalTokens" : 2000
      },
      {
        "firstTokenLatency" : 0.1054229736328125,
        "promptDecodingTime" : 0.004083991050720215,
        "tokensPerSecond" : 24.267726513177738,
        "totalTime" : 82.41806697845459,
        "totalTokens" : 2000
      }
    ],
    "name" : "Basic benchmark",
    "summary" : {
      "avgFirstTokenLatency" : 0.11128966013590495,
      "avgPromptDecodingTime" : 0.004334012667338054,
      "avgTokensPerSecond" : 28.23945211046355,
      "avgTotalTime" : 71.59333503246307,
      "maxFirstTokenLatency" : 0.1292719841003418,
      "maxPromptDecodingTime" : 0.005144000053405762,
      "maxTotalTime" : 82.41806697845459,
      "minFirstTokenLatency" : 0.09917402267456055,
      "minPromptDecodingTime" : 0.0037740468978881836,
      "minTotalTime" : 65.50896310806274
    },
    "timestamp" : "2025-09-15T08:03:53Z"
  }
]</code></pre>
    </td>
    <td style="vertical-align:top; padding:8px;">
<pre><code class="language-json">[
  {
    "metrics" : [
      {
        "firstTokenLatency" : 0.10444998741149902,
        "promptDecodingTime" : 0.005648970603942871,
        "tokensPerSecond" : 71.20365187144678,
        "totalTime" : 28.094095945358276,
        "totalTokens" : 2000
      },
      {
        "firstTokenLatency" : 0.09721696376800537,
        "promptDecodingTime" : 0.00541996955871582,
        "tokensPerSecond" : 67.10931282708418,
        "totalTime" : 29.807543992996216,
        "totalTokens" : 2000
      },
      {
        "firstTokenLatency" : 0.10307300090789795,
        "promptDecodingTime" : 0.005450010299682617,
        "tokensPerSecond" : 64.98256557293409,
        "totalTime" : 30.782937049865723,
        "totalTokens" : 2000
      }
    ],
    "name" : "Basic benchmark",
    "summary" : {
      "avgFirstTokenLatency" : 0.10157998402913411,
      "avgPromptDecodingTime" : 0.0055063168207804365,
      "avgTokensPerSecond" : 67.76517675715502,
      "avgTotalTime" : 29.56152566274007,
      "maxFirstTokenLatency" : 0.10444998741149902,
      "maxPromptDecodingTime" : 0.005648970603942871,
      "maxTotalTime" : 30.782937049865723,
      "minFirstTokenLatency" : 0.09721696376800537,
      "minPromptDecodingTime" : 0.00541996955871582,
      "minTotalTime" : 28.094095945358276
    },
    "timestamp" : "2025-09-15T07:28:09Z"
  }
]</code></pre>
    </td>
  </tr>
</table>

```
swift run -c release LocalLLMCLI benchmark --model ~/.localllmclient/huggingface/models/lmstudio-community/gemma-3-4B-it-qat-GGUF/gemma-3-4B-it-QAT-Q4_0.gguf --output ~/Desktop/results.json
```

*M1 Max*

</details>

--- 
This pull request introduces two new commands to the CLI (`benchmark` and `run`) for interacting with local LLMs, along with supporting infrastructure for backend selection and error handling. The changes add comprehensive benchmarking capabilities, support for multiple backends, and improved model downloading logic. The most important changes are grouped below:

### New CLI Commands

* Added `BenchmarkCommand` in `BenchmarkCommand.swift` to run performance benchmarks on local LLMs, supporting various modes (basic, context, batch, all), custom prompts, iterations, context/batch sizes, and automatic model downloading from HuggingFace. Results are output in JSON format with detailed metrics.
* Added `RunCommand` in `RunCommand.swift` to run a single prompt through a local LLM, supporting backend selection (`llama`, `mlx`, `foundation-models`), sampling parameters, image attachments, and model downloading logic.

### Backend and Error Handling Infrastructure

* Introduced the `Backend` enum for backend selection and the `LocalLLMCommandError` enum for consistent error handling in `Common.swift`.

### Codebase Cleanup

* Removed unnecessary imports and platform-specific code from `command.swift`, centralizing logic in the new command files.