### PR TITLE
Improve progress handling in FileManager

### DIFF
--- a/Sources/LocalLLMClientUtility/Downloader.swift
+++ b/Sources/LocalLLMClientUtility/Downloader.swift
@@ -3,6 +3,7 @@ import Foundation
 import FoundationNetworking
 #endif
 
+@MainActor
 final class Downloader {
     private(set) var downloaders: [ChildDownloader] = []
     let progress = Progress(totalUnitCount: 0)
@@ -30,8 +31,6 @@ final class Downloader {
 
     func add(_ downloader: ChildDownloader) {
         downloaders.append(downloader)
-        progress.addChild(downloader.progress, withPendingUnitCount: 1)
-        progress.totalUnitCount += 1
     }
 
     func setObserver(_ action: @Sendable @escaping (Progress) async -> Void) {
@@ -56,13 +55,33 @@ final class Downloader {
 #endif
     }
 
-    func download() {
+    func download() async {
         guard !downloaders.isEmpty else {
             // Notify that download is complete
             progress.totalUnitCount = 1
             progress.completedUnitCount = 1
             return
         }
+        
+        // Fetch file sizes first
+        var totalBytes: Int64 = 0
+        for downloader in downloaders {
+            if !downloader.isDownloaded {
+                let size = await downloader.fetchFileSize()
+                if size > 0 {
+                    totalBytes += size
+                    progress.addChild(downloader.progress, withPendingUnitCount: size)
+                } else {
+                    // If we can't get the size, use a default weight
+                    progress.addChild(downloader.progress, withPendingUnitCount: 1_000_000)
+                    totalBytes += 1_000_000
+                }
+            }
+        }
+
+        progress.totalUnitCount = totalBytes
+
+        // Start downloads
         for downloader in downloaders {
             downloader.download()
         }
@@ -101,6 +120,7 @@ extension Downloader {
         private let url: URL
         private let destinationURL: URL
         private let session: Locked<URLSession>
+        private let headSession: URLSession
         private let delegate = Delegate()
         private let currentTask = Locked<URLSessionTask?>(nil)
 
@@ -130,11 +150,12 @@ extension Downloader {
             }
         }
 
-        public init(url: URL, destinationURL: URL, configuration: URLSessionConfiguration = .default) {
+        public init(url: URL, destinationURL: URL, configuration: URLSessionConfiguration = .default, headSessionConfiguration: URLSessionConfiguration = .ephemeral) {
             self.url = url
             self.destinationURL = destinationURL
             let session = URLSession(configuration: configuration, delegate: delegate, delegateQueue: nil)
             self.session = Locked(session)
+            self.headSession = URLSession(configuration: headSessionConfiguration)
 
 #if !os(Linux)
             Task {
@@ -149,7 +170,29 @@ extension Downloader {
 #endif
         }
 
-        public func download(existingTask: URLSessionTask? = nil) {
+        func fetchFileSize() async -> Int64 {
+            // Skip if already downloaded
+            if isDownloaded {
+                return 0
+            }
+            
+            var request = URLRequest(url: url)
+            request.httpMethod = "HEAD"
+            
+            do {
+                let (_, response) = try await headSession.data(for: request)
+                if let httpResponse = response as? HTTPURLResponse,
+                   let contentLength = httpResponse.value(forHTTPHeaderField: "Content-Length"),
+                   let size = Int64(contentLength) {
+                    return size
+                }
+            } catch {
+                // If HEAD request fails, return 0
+            }
+            return 0
+        }
+        
+        func download(existingTask: URLSessionTask? = nil) {
             guard !isDownloading else { return }
             delegate.state.withLock { $0 = .downloading }
 
@@ -164,7 +207,7 @@ extension Downloader {
             task.resume()
         }
         
-        public func cancel() {
+        func cancel() {
             currentTask.withLock { task in
                 task?.cancel()
                 task = nil
@@ -178,7 +221,7 @@ extension Downloader {
             reset()
         }
 
-        public func reset() {
+        func reset() {
             session.withLock {
                 $0.invalidateAndCancel()
                 $0 = URLSession(configuration: $0.configuration, delegate: delegate, delegateQueue: nil)

--- a/Sources/LocalLLMClientUtility/HuggingFaceAPI.swift
+++ b/Sources/LocalLLMClientUtility/HuggingFaceAPI.swift
@@ -165,10 +165,10 @@ public struct HuggingFaceAPI: Sendable {
         // Get files to download
         let fileInfos = try await getFileInfo(matching: globs, revision: revision, configuration: configuration)
 
-        let downloader = Downloader()
+        let downloader = await Downloader()
         for fileInfo in fileInfos {
             let type = repo.type == .models ? "" : "\(repo.type.rawValue)/"
-            downloader.add(.init(
+            await downloader.add(.init(
                 url: endpoint.appending(path: "\(type)\(repo.id)/resolve/\(revision)/\(fileInfo.filename)"),
                 destinationURL: destination.appendingPathComponent(fileInfo.filename),
                 configuration: {
@@ -182,11 +182,11 @@ public struct HuggingFaceAPI: Sendable {
                 }()
             ))
         }
-        downloader.setObserver { progress in
+        await downloader.setObserver { progress in
             await progressHandler(progress)
         }
 
-        downloader.download()
+        await downloader.download()
         try await downloader.waitForDownloads()
 
         await progressHandler(downloader.progress)


### PR DESCRIPTION
https://github.com/tattn/LocalLLMClient/issues/57

- Improve progress handling in FileManager

--- 
This pull request refactors the `Downloader` utility to improve download progress tracking by using actual file sizes, introduces async/await to the download workflow, and updates the test infrastructure to support HEAD request simulation. These changes ensure more accurate progress reporting and better test coverage for edge cases.

### Downloader improvements

* The `Downloader` class now calculates progress using the actual file sizes by performing async HEAD requests before downloading, rather than assigning a fixed weight to each file. This results in more accurate progress reporting. (`Downloader.swift` [Sources/LocalLLMClientUtility/Downloader.swiftL59-R84](diffhunk://#diff-f4767c8fb434a23bdc786927cc79fb73bf39a97edfe66b997b25f04143026237L59-R84))
* The `download()` method and related methods in `Downloader` and `ChildDownloader` are now async, enabling concurrent file size fetching and downloads. (`Downloader.swift` [[1]](diffhunk://#diff-f4767c8fb434a23bdc786927cc79fb73bf39a97edfe66b997b25f04143026237L59-R84) [[2]](diffhunk://#diff-8f4b09598a00683720624fe04eb1ae48ca1390603b8e2693aafa0886576c9885L168-R171) [[3]](diffhunk://#diff-8f4b09598a00683720624fe04eb1ae48ca1390603b8e2693aafa0886576c9885L185-R189)
* Added a `fetchFileSize()` async method to `ChildDownloader`, which performs a HEAD request to retrieve the `Content-Length` for each file. (`Downloader.swift` [Sources/LocalLLMClientUtility/Downloader.swiftL152-R195](diffhunk://#diff-f4767c8fb434a23bdc786927cc79fb73bf39a97edfe66b997b25f04143026237L152-R195))

### API and method signature changes

* The `Downloader` and `ChildDownloader` methods (`add`, `setObserver`, `download`, `cancel`, `reset`) are no longer `public` and now support async/await, requiring callers to use `await` when invoking them. (`Downloader.swift` [[1]](diffhunk://#diff-f4767c8fb434a23bdc786927cc79fb73bf39a97edfe66b997b25f04143026237L33-L34) [[2]](diffhunk://#diff-f4767c8fb434a23bdc786927cc79fb73bf39a97edfe66b997b25f04143026237L167-R210) [[3]](diffhunk://#diff-f4767c8fb434a23bdc786927cc79fb73bf39a97edfe66b997b25f04143026237L181-R224)

### Test infrastructure enhancements

* The `MockURLProtocol` in tests now supports simulating HEAD requests and allows forced failures via a new `failHead` flag, improving test coverage for error handling and progress calculation. (`MockURLProtocol.swift` [[1]](diffhunk://#diff-23ee364218b1bd521000978e89660c0b55db827b38ece40daa8aad01ea8212fcL10-R10) [[2]](diffhunk://#diff-23ee364218b1bd521000978e89660c0b55db827b38ece40daa8aad01ea8212fcL22-R30) [[3]](diffhunk://#diff-23ee364218b1bd521000978e89660c0b55db827b38ece40daa8aad01ea8212fcR73-R84)