### PR TITLE
Add modelPath property to DownloadModel and LocalModel

### DIFF
--- a/Sources/LocalLLMClientCore/LLMSession.swift
+++ b/Sources/LocalLLMClientCore/LLMSession.swift
@@ -271,6 +271,11 @@ public extension LLMSession {
             downloader.isDownloaded
         }
 
+        /// The local path where the model files are stored.
+        public var modelPath: URL {
+            downloader.destination
+        }
+
         package init(source: FileDownloader.Source, destination: URL? = nil, makeClient: @Sendable @escaping ([AnyLLMTool]) async throws -> AnyLLMClient) {
             self.source = source
             let destination = destination ?? FileDownloader.defaultRootDestination
@@ -301,8 +306,12 @@ public extension LLMSession {
     
     struct LocalModel: Model {
         public let makeClient: @Sendable ([AnyLLMTool]) async throws -> AnyLLMClient
-        
-        package init(makeClient: @Sendable @escaping ([AnyLLMTool]) async throws -> AnyLLMClient) {
+
+        /// The local path of the model.
+        public let modelPath: URL
+
+        package init(modelPath: URL, makeClient: @Sendable @escaping ([AnyLLMTool]) async throws -> AnyLLMClient) {
+            self.modelPath = modelPath
             self.makeClient = makeClient
         }
         

--- a/Sources/LocalLLMClientLlama/LLMSession+Llama.swift
+++ b/Sources/LocalLLMClientLlama/LLMSession+Llama.swift
@@ -44,6 +44,7 @@ public extension LLMSession.LocalModel {
         parameter: LlamaClient.Parameter = .default
     ) -> LLMSession.LocalModel {
         return LLMSession.LocalModel(
+            modelPath: url,
             makeClient: { tools in
                 try await AnyLLMClient(
                     LocalLLMClient.llama(

--- a/Sources/LocalLLMClientMLX/LLMSession+MLX.swift
+++ b/Sources/LocalLLMClientMLX/LLMSession+MLX.swift
@@ -31,6 +31,7 @@ public extension LLMSession.LocalModel {
         parameter: MLXClient.Parameter = .default
     ) -> LLMSession.LocalModel {
         return LLMSession.LocalModel(
+            modelPath: url,
             makeClient: { tools in
                 try await AnyLLMClient(
                     LocalLLMClient.mlx(url: url, parameter: parameter, tools: tools.map { $0.underlyingTool })

--- a/Tests/LocalLLMClientLlamaTests/LLMSessionLlamaTests.swift
+++ b/Tests/LocalLLMClientLlamaTests/LLMSessionLlamaTests.swift
@@ -115,6 +115,19 @@ extension ModelTests {
         }
         
         @Test
+        func downloadModelPath() async throws {
+            let downloadModel = Self.makeGeneralModel()
+
+            // Check that modelPath is accessible
+            let modelPath = downloadModel.modelPath
+            #expect(modelPath.path.contains(".localllmclient/huggingface/models"))
+
+            // The path should contain the HuggingFace repository ID
+            let info = LocalLLMClient.modelInfo(for: .general, modelSize: .default)
+            #expect(modelPath.path.contains(info.id.split(separator: "/").last ?? ""), "Model path should contain repository name")
+        }
+
+        @Test
         func localModelLoading() async throws {
             // First download the model to ensure we have a local copy
             let info = LocalLLMClient.modelInfo(for: .general, modelSize: .light)
@@ -124,6 +137,9 @@ extension ModelTests {
             // Create a session with the local model
             let localModel = LLMSession.LocalModel.llama(url: modelPath)
             let session = LLMSession(model: localModel)
+
+            // Verify the model path is accessible
+            #expect(localModel.modelPath == modelPath, "LocalModel should store the provided model path")
             
             // Test that it works
             let response = try await session.respond(to: "Hi, can you say hello?")


### PR DESCRIPTION
- Add modelPath property to DownloadModel and LocalModel

---

This pull request introduces improvements to how local model file paths are handled and accessed in the `LLMSession` API, as well as updates related tests to verify the new behavior. The main change is the addition of a public property for accessing the local model path, which is now consistently tracked and exposed throughout the API and its test coverage.

**API enhancements (Local model path handling):**

* Added a public `modelPath` property to `LLMSession` to expose the local path where model files are stored, making it easier to access and use model files programmatically.
* Updated the `LLMSession.LocalModel` struct to include a public `modelPath` property, ensuring that the model path is tracked and accessible for all local models.

**Integration with model initializers:**

* Modified the `llama` and `mlx` model initializers to set the new `modelPath` property, ensuring the path is available when creating models for both Llama and MLX backends. [[1]](diffhunk://#diff-84d90b98ad201801b2354bd1adea33b606903cb2494f9577cd2ac456880d77a7R47) [[2]](diffhunk://#diff-66fae2ca2099ed3dfde34756573fe9b87603c305a36c6a55a34f5ca94098a16fR34)

**Test coverage improvements:**

* Added new tests to verify that the `modelPath` property is correctly set and contains expected values, including checks for the HuggingFace repository name in the path.
* Updated existing local model loading tests to assert that the `modelPath` property matches the provided path, ensuring correctness in model instantiation.