### PR TITLE
Enable pruning downloaded models

### DIFF
--- a/Sources/LocalLLMClientCore/LLMSession.swift
+++ b/Sources/LocalLLMClientCore/LLMSession.swift
@@ -303,10 +303,13 @@ public extension LLMSession {
             try await downloader.download(onProgress: onProgress)
         }
 
-        public static func pruneModels(in url: URL = FileDownloader.defaultRootDestination, excluding: [Model] = []) throws {
+        public static func removeAllModels(
+            in url: URL = FileDownloader.defaultRootDestination,
+            excludingModels: [any Model] = []
+        ) throws {
             guard let enumerator = FileManager.default.enumerator(at: url, includingPropertiesForKeys: [.isDirectoryKey], options: [.skipsPackageDescendants]) else { return }
 
-            let excludingNormalized: Set<URL> = Set(excluding.compactMap { model -> URL? in
+            let excludingNormalized: Set<URL> = Set(excludingModels.compactMap { model -> URL? in
                 if let model = model as? LLMSession.DownloadModel {
                     return model.modelPath.resolvingSymlinksInPath().standardizedFileURL
                 }

--- a/Sources/LocalLLMClientCore/LLMSession.swift
+++ b/Sources/LocalLLMClientCore/LLMSession.swift
@@ -330,7 +330,7 @@ public extension LLMSession {
                 }
             }
 
-            try url.removeEmptyFolders()
+            try FileManager.default.removeEmptyDirectories(in: url)
         }
     }
     

--- a/Sources/LocalLLMClientCore/LLMSession.swift
+++ b/Sources/LocalLLMClientCore/LLMSession.swift
@@ -322,7 +322,7 @@ public extension LLMSession {
                     continue
                 }
 
-                if (try? fileURL.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == false {
+                if (try fileURL.resourceValues(forKeys: [.isDirectoryKey])).isDirectory == false {
                     try FileManager.default.removeItem(at: fileURL)
                 }
             }

--- a/Sources/LocalLLMClientUtility/FileManager+.swift
+++ b/Sources/LocalLLMClientUtility/FileManager+.swift
@@ -13,4 +13,24 @@ package extension FileManager {
 
         try removeItem(at: url)
     }
+
+    func removeAllItems(in url: URL, excludingURLs: [URL] = [], removingEmptyDirectories: Bool = true) throws {
+        guard let enumerator = enumerator(at: url, includingPropertiesForKeys: [.isDirectoryKey], options: [.skipsPackageDescendants]) else { return }
+
+        let excludingURLsNormalized: Set<URL> = Set(excludingURLs.map { $0.resolvingSymlinksInPath().standardizedFileURL
+        })
+
+        for case let fileURL as URL in enumerator {
+            if excludingURLsNormalized.contains(fileURL.resolvingSymlinksInPath().standardizedFileURL) {
+                enumerator.skipDescendants()
+                continue
+            }
+
+            if (try fileURL.resourceValues(forKeys: [.isDirectoryKey])).isDirectory == false {
+                try removeItem(at: fileURL)
+            }
+        }
+
+        if removingEmptyDirectories { try removeEmptyDirectories(in: url) }
+    }
 }

--- a/Sources/LocalLLMClientUtility/FileManager+.swift
+++ b/Sources/LocalLLMClientUtility/FileManager+.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+package extension FileManager {
+    func removeEmptyDirectories(in url: URL) throws {
+        guard url.isFileURL else { return }
+
+        let contents = try contentsOfDirectory(at: url, includingPropertiesForKeys: [.isDirectoryKey])
+        let subdirectories = try contents.filter { try $0.resourceValues(forKeys: [.isDirectoryKey]).isDirectory ?? false }
+
+        for subdirectory in subdirectories { try removeEmptyDirectories(in: subdirectory) }
+
+        guard try contentsOfDirectory(at: url, includingPropertiesForKeys: nil).isEmpty else { return }
+
+        try removeItem(at: url)
+    }
+}

--- a/Sources/LocalLLMClientUtility/URL+.swift
+++ b/Sources/LocalLLMClientUtility/URL+.swift
@@ -23,7 +23,7 @@ package extension URL {
         guard isFileURL else { return }
 
         let contents = try FileManager.default.contentsOfDirectory(at: self, includingPropertiesForKeys: [.isDirectoryKey])
-        let subdirectories = contents.filter { (try? $0.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true }
+        let subdirectories = try contents.filter { try $0.resourceValues(forKeys: [.isDirectoryKey]).isDirectory ?? false }
 
         for subdirectory in subdirectories { try subdirectory.removeEmptyFolders() }
 

--- a/Sources/LocalLLMClientUtility/URL+.swift
+++ b/Sources/LocalLLMClientUtility/URL+.swift
@@ -18,17 +18,4 @@ package extension URL {
         return url
 #endif
     }
-
-    func removeEmptyFolders() throws {
-        guard isFileURL else { return }
-
-        let contents = try FileManager.default.contentsOfDirectory(at: self, includingPropertiesForKeys: [.isDirectoryKey])
-        let subdirectories = try contents.filter { try $0.resourceValues(forKeys: [.isDirectoryKey]).isDirectory ?? false }
-
-        for subdirectory in subdirectories { try subdirectory.removeEmptyFolders() }
-
-        guard try FileManager.default.contentsOfDirectory(at: self, includingPropertiesForKeys: nil).isEmpty else { return }
-
-        try FileManager.default.removeItem(at: self)
-    }
 }

--- a/Sources/LocalLLMClientUtility/URL+.swift
+++ b/Sources/LocalLLMClientUtility/URL+.swift
@@ -18,4 +18,17 @@ package extension URL {
         return url
 #endif
     }
+
+    func removeEmptyFolders() throws {
+        guard isFileURL else { return }
+
+        let contents = try FileManager.default.contentsOfDirectory(at: self, includingPropertiesForKeys: [.isDirectoryKey])
+        let subdirectories = contents.filter { (try? $0.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true }
+
+        for subdirectory in subdirectories { try subdirectory.removeEmptyFolders() }
+
+        guard try FileManager.default.contentsOfDirectory(at: self, includingPropertiesForKeys: nil).isEmpty else { return }
+
+        try FileManager.default.removeItem(at: self)
+    }
 }


### PR DESCRIPTION
This adds a static `pruneModels(in:excluding:)` method to DownloadModel.

Addresses #63.

This allows for maintaining a single canonical model in an app via:

```
let model = LLMSession.DownloadModel.llama(
    id: "Qwen/Qwen2.5-1.5B-Instruct-GGUF",
    model: "qwen2.5-1.5b-instruct-q4_k_m.gguf",
)

LLMSession.DownloadModel.pruneModels(excluding: [model])
```