### PR TITLE
Support streaming responses for tool calls

### DIFF
--- a/Sources/LocalLLMClientCore/AnyLLMClient.swift
+++ b/Sources/LocalLLMClientCore/AnyLLMClient.swift
@@ -106,7 +106,7 @@ public struct AnyLLMClient: LLMClient {
         withToolCalls toolCalls: [LLMToolCall],
         toolOutputs: [(String, String)],
         originalInput: LLMInput
-    ) async throws -> AsyncThrowingStream<StreamingChunk, Error> {
+    ) async throws -> AsyncThrowingStream<StreamingChunk, any Error> {
         try await _resumeStream(toolCalls, toolOutputs, originalInput)
     }
 

--- a/Sources/LocalLLMClientCore/AnyLLMClient.swift
+++ b/Sources/LocalLLMClientCore/AnyLLMClient.swift
@@ -6,6 +6,7 @@ public struct AnyLLMClient: LLMClient {
     private let _textStream: @Sendable (LLMInput) async throws -> AsyncThrowingStream<String, Error>
     private let _generateToolCalls: @Sendable (LLMInput) async throws -> GeneratedContent
     private let _resume: @Sendable ([LLMToolCall], [(String, String)], LLMInput) async throws -> String
+    private let _resumeStream: @Sendable ([LLMToolCall], [(String, String)], LLMInput) async throws -> AsyncThrowingStream<StreamingChunk, Error>
     private let _responseStream: @Sendable (LLMInput) async throws -> AsyncThrowingStream<StreamingChunk, Error>
     private let _pauseGeneration: @Sendable () async -> Void
     private let _resumeGeneration: @Sendable () async -> Void
@@ -32,6 +33,17 @@ public struct AnyLLMClient: LLMClient {
                 toolOutputs: toolOutputs,
                 originalInput: originalInput
             )
+        }
+        self._resumeStream = { toolCalls, toolOutputs, originalInput in
+            Self.createAsyncStream { continuation in
+                for try await content in try await client.resumeStream(
+                    withToolCalls: toolCalls,
+                    toolOutputs: toolOutputs,
+                    originalInput: originalInput
+                ) {
+                    continuation.yield(content)
+                }
+            }
         }
         self._responseStream = { input in
             Self.createAsyncStream { continuation in
@@ -69,19 +81,19 @@ public struct AnyLLMClient: LLMClient {
             }
         }
     }
-    
+
     public func generateText(from input: LLMInput) async throws -> String {
         try await _generateText(input)
     }
-    
+
     public func textStream(from input: LLMInput) async throws -> AsyncThrowingStream<String, Error> {
         try await _textStream(input)
     }
-    
+
     public func generateToolCalls(from input: LLMInput) async throws -> GeneratedContent {
         try await _generateToolCalls(input)
     }
-    
+
     public func resume(
         withToolCalls toolCalls: [LLMToolCall],
         toolOutputs: [(String, String)],
@@ -89,7 +101,15 @@ public struct AnyLLMClient: LLMClient {
     ) async throws -> String {
         try await _resume(toolCalls, toolOutputs, originalInput)
     }
-    
+
+    public func resumeStream(
+        withToolCalls toolCalls: [LLMToolCall],
+        toolOutputs: [(String, String)],
+        originalInput: LLMInput
+    ) async throws -> AsyncThrowingStream<StreamingChunk, Error> {
+        try await _resumeStream(toolCalls, toolOutputs, originalInput)
+    }
+
     public func responseStream(from input: LLMInput) async throws -> AsyncThrowingStream<StreamingChunk, Error> {
         try await _responseStream(input)
     }

--- a/Sources/LocalLLMClientCore/AnyLLMClient.swift
+++ b/Sources/LocalLLMClientCore/AnyLLMClient.swift
@@ -6,7 +6,7 @@ public struct AnyLLMClient: LLMClient {
     private let _textStream: @Sendable (LLMInput) async throws -> AsyncThrowingStream<String, Error>
     private let _generateToolCalls: @Sendable (LLMInput) async throws -> GeneratedContent
     private let _resume: @Sendable ([LLMToolCall], [(String, String)], LLMInput) async throws -> String
-    private let _resumeStream: @Sendable ([LLMToolCall], [(String, String)], LLMInput) async throws -> AsyncThrowingStream<StreamingChunk, Error>
+    private let _resumeStream: @Sendable ([LLMToolCall], [(String, String)], LLMInput) async throws -> AsyncThrowingStream<StreamingChunk, any Error>
     private let _responseStream: @Sendable (LLMInput) async throws -> AsyncThrowingStream<StreamingChunk, Error>
     private let _pauseGeneration: @Sendable () async -> Void
     private let _resumeGeneration: @Sendable () async -> Void

--- a/Sources/LocalLLMClientCore/LLMClient.swift
+++ b/Sources/LocalLLMClientCore/LLMClient.swift
@@ -4,6 +4,7 @@ import Foundation
 public protocol LLMClient: Sendable {
     associatedtype TextGenerator: AsyncSequence & Sendable where Self.TextGenerator.Element == String
     associatedtype ResponseGenerator: AsyncSequence & Sendable where Self.ResponseGenerator.Element == StreamingChunk
+    associatedtype ResumeGenerator: AsyncSequence & Sendable where Self.ResumeGenerator.Element == StreamingChunk
 
     /// Processes the provided input and returns the complete generated text
     /// - Parameter input: The input to process
@@ -16,38 +17,51 @@ public protocol LLMClient: Sendable {
     /// - Returns: An asynchronous sequence that emits text tokens
     /// - Throws: An error if text generation fails
     func textStream(from input: LLMInput) async throws -> TextGenerator
-    
+
     /// Generates text with tool calls from the given input.
     /// - Parameter input: The input to generate from
     /// - Returns: Generated content containing text and optional tool calls
     /// - Throws: An error if generation fails or tools are not supported
     func generateToolCalls(from input: LLMInput) async throws -> GeneratedContent
-    
-    /// Resumes generation after tool calls have been executed.
+
+    /// Resumes generation after tool calls have been executed and returns the complete generated text.
     /// - Parameters:
     ///   - toolCalls: The tool calls that were made
     ///   - toolOutputs: The outputs from executing the tools (id, output) pairs
     ///   - originalInput: The original input that triggered the tool calls
-    /// - Returns: The final generated text after processing tool outputs
+    /// - Returns: The complete generated text after resumption
     /// - Throws: An error if resumption fails or tools are not supported
     func resume(
         withToolCalls toolCalls: [LLMToolCall],
         toolOutputs: [(String, String)],
         originalInput: LLMInput
     ) async throws -> String
-    
+
+    /// Resumes generation after tool calls have been executed and returns a stream.
+    /// - Parameters:
+    ///   - toolCalls: The tool calls that were made
+    ///   - toolOutputs: The outputs from executing the tools (id, output) pairs
+    ///   - originalInput: The original input that triggered the tool calls
+    /// - Returns: An asynchronous sequence that emits response content (text chunks, tool calls, etc.)
+    /// - Throws: An error if resumption fails or tools are not supported
+    func resumeStream(
+        withToolCalls toolCalls: [LLMToolCall],
+        toolOutputs: [(String, String)],
+        originalInput: LLMInput
+    ) async throws -> ResumeGenerator
+
     /// Generates a stream of responses from the given input.
     /// - Parameter input: The input to generate from
     /// - Returns: An asynchronous sequence that emits response content (text chunks, tool calls, etc.)
     /// - Throws: An error if generation fails or requested features are not supported
     func responseStream(from input: LLMInput) async throws -> ResponseGenerator
-    
+
     /// Pauses any ongoing text generation
     func pauseGeneration() async
-    
+
     /// Resumes previously paused text generation
     func resumeGeneration() async
-    
+
     /// Whether the generation is currently paused
     var isGenerationPaused: Bool { get async }
 }
@@ -63,6 +77,31 @@ public extension LLMClient {
             finalResult += token
         }
         return finalResult
+    }
+
+    /// Resumes generation after tool calls have been executed and returns the complete generated text.
+    /// - Parameters:
+    ///   - toolCalls: The tool calls that were made
+    ///   - toolOutputs: The outputs from executing the tools (id, output) pairs
+    ///   - originalInput: The original input that triggered the tool calls
+    /// - Returns: The complete generated text after resumption
+    /// - Throws: An error if resumption fails or tools are not supported
+    func resume(
+        withToolCalls toolCalls: [LLMToolCall],
+        toolOutputs: [(String, String)],
+        originalInput: LLMInput
+    ) async throws -> String {
+        var result = ""
+        for try await chunk in try await resumeStream(withToolCalls: toolCalls, toolOutputs: toolOutputs, originalInput: originalInput) {
+            switch chunk {
+            case .text(let text):
+                result += text
+            case .toolCall:
+                // Tool calls in resume are not expected but handled for completeness
+                break
+            }
+        }
+        return result
     }
 
     /// Convenience method to generate text from a plain string input
@@ -83,23 +122,20 @@ public extension LLMClient {
 }
 
 // Extension for default tool calling behavior
-public extension LLMClient where ResponseGenerator == AsyncThrowingStream<StreamingChunk, Error> {
-    /// Default implementation that throws an error for clients that don't support tool calls
+public extension LLMClient where ResponseGenerator == AsyncThrowingStream<StreamingChunk, any Error>, ResumeGenerator == AsyncThrowingStream<StreamingChunk, any Error> {
     func generateToolCalls(from input: LLMInput) async throws -> GeneratedContent {
         throw LLMError.invalidParameter(reason: "Tool calls are not supported by this LLM client")
     }
-    
-    /// Default implementation that throws an error for clients that don't support tool calls
-    func resume(
+
+    func resumeStream(
         withToolCalls toolCalls: [LLMToolCall],
         toolOutputs: [(String, String)],
         originalInput: LLMInput
-    ) async throws -> String {
+    ) async throws -> AsyncThrowingStream<StreamingChunk, any Error> {
         throw LLMError.invalidParameter(reason: "Tool calls are not supported by this LLM client")
     }
-    
-    /// Default implementation that throws an error for clients that don't support tool calls
-    func responseStream(from input: LLMInput) async throws -> AsyncThrowingStream<StreamingChunk, Error> {
+
+    func responseStream(from input: LLMInput) async throws -> AsyncThrowingStream<StreamingChunk, any Error> {
         throw LLMError.invalidParameter(reason: "Tool calls are not supported by this LLM client")
     }
 }

--- a/Sources/LocalLLMClientLlama/LlamaClient.swift
+++ b/Sources/LocalLLMClientLlama/LlamaClient.swift
@@ -100,34 +100,28 @@ public final class LlamaClient: LLMClient {
     ///   - originalInput: The original input that generated the tool call
     /// - Returns: The model's response to the tool outputs
     /// - Throws: An error if text generation fails
-    public func resume(
+    public func resumeStream(
         withToolCalls toolCalls: [LLMToolCall],
         toolOutputs: [(String, String)],
         originalInput: LLMInput
-    ) async throws -> String {
+    ) async throws -> AsyncThrowingStream<StreamingChunk, any Error> {
         guard case let .chat(messages) = originalInput.value else {
             throw LLMError.invalidParameter(reason: "Original input must be a chat")
         }
-        
-        var updatedMessages = messages
 
-        // Add tool messages for each tool output
+        var updatedMessages = messages
         for (toolCallID, output) in toolOutputs {
             updatedMessages.append(.tool(output, toolCallID: toolCallID))
         }
-        
-        // Create a new input with the updated messages
-        let updatedInput = LLMInput.chat(updatedMessages)
-        
-        // Generate a response to the tool outputs
-        return try await generateText(from: updatedInput)
+
+        return try await responseStream(from: .chat(updatedMessages))
     }
     
     /// Streams responses from the input
     /// - Parameter input: The input to process
     /// - Returns: An asynchronous sequence that emits response content (text chunks, tool calls, etc.)
     /// - Throws: An error if generation fails
-    public func responseStream(from input: LLMInput) async throws -> AsyncThrowingStream<StreamingChunk, Error> {
+    public func responseStream(from input: LLMInput) async throws -> AsyncThrowingStream<StreamingChunk, any Error> {
         // Create the stream first (this can throw)
         let textStreamGenerator = try textStream(from: input)
         let chatFormat = self.chatFormat

--- a/Sources/LocalLLMClientLlama/Sampler.swift
+++ b/Sources/LocalLLMClientLlama/Sampler.swift
@@ -13,7 +13,7 @@ package extension Sampler {
     func sample(context: Context, index: Int32) -> llama_token {
         let logits = llama_get_logits_ith(context.context, index)!
 
-        for tokenID in context.cursorPointer.indices { // faster than using range
+        for tokenID in context.cursorPointer.indices {
             context.cursorPointer[tokenID] = llama_token_data(
                 id: Int32(tokenID), logit: logits[tokenID], p: 0.0
             )

--- a/Tests/LocalLLMClientTests/StreamingToolCallTests.swift
+++ b/Tests/LocalLLMClientTests/StreamingToolCallTests.swift
@@ -129,11 +129,21 @@ private final class MockStreamingToolCallClient: LLMClient, @unchecked Sendable 
     func generateToolCalls(from input: LLMInput) async throws -> GeneratedContent {
         GeneratedContent(text: "Mock response")
     }
-    
-    func resume(withToolCalls toolCalls: [LLMToolCall], toolOutputs: [(String, String)], originalInput: LLMInput) async throws -> String {
-        "Found information about weather"
+
+    func resumeStream(
+        withToolCalls toolCalls: [LLMToolCall],
+        toolOutputs: [(String, String)],
+        originalInput: LLMInput
+    ) async throws -> AsyncThrowingStream<StreamingChunk, any Error> {
+        return AsyncThrowingStream { continuation in
+            Task {
+                let resultText = "Based on the tool results: \(toolOutputs.map { $0.1 }.joined(separator: ", "))"
+                continuation.yield(.text(resultText))
+                continuation.finish()
+            }
+        }
     }
-    
+
     func responseStream(from input: LLMInput) async throws -> AsyncThrowingStream<StreamingChunk, Error> {
         AsyncThrowingStream { continuation in
             Task {


### PR DESCRIPTION
https://github.com/tattn/LocalLLMClient/issues/70

- Support streaming responses for tool calls

---
This pull request refactors the tool call resumption API in the LLM client codebase to use a streaming interface instead of returning a single string. This change improves consistency across the API and enables more flexible handling of streaming responses, especially when resuming generation after tool calls. Several classes and protocols have been updated to support this new approach, and related tests have been modified accordingly.

### API Changes

* The `LLMClient` protocol replaces the `resume` method (which returned a `String`) with `resumeStream`, which returns an asynchronous stream of `StreamingChunk` objects. This change is reflected in all conforming classes and the type-erased wrapper `AnyLLMClient`. [[1]](diffhunk://#diff-124615213a0998a217e78652931c9bcee3d4761694732bf7990a7674cf6672dcL26-R38) [[2]](diffhunk://#diff-9840521b418a3b7b07a99c8de66841125a18bd665468ffd6337dbece1bdb27d3L5-L18) [[3]](diffhunk://#diff-9840521b418a3b7b07a99c8de66841125a18bd665468ffd6337dbece1bdb27d3L29-R34) [[4]](diffhunk://#diff-9840521b418a3b7b07a99c8de66841125a18bd665468ffd6337dbece1bdb27d3L73-L76) [[5]](diffhunk://#diff-9840521b418a3b7b07a99c8de66841125a18bd665468ffd6337dbece1bdb27d3L85-R86)
* Default protocol implementations and error handling are updated to support the new streaming interface, including a helper method to collect the stream into a string if needed. [[1]](diffhunk://#diff-124615213a0998a217e78652931c9bcee3d4761694732bf7990a7674cf6672dcR69-R87) [[2]](diffhunk://#diff-124615213a0998a217e78652931c9bcee3d4761694732bf7990a7674cf6672dcL86-R119)

### Implementation Updates

* The `LlamaClient` and `MLXClient` classes now implement `resumeStream` to return a stream of response chunks, rather than a single string. The `responseStream` method signatures are updated for consistency. [[1]](diffhunk://#diff-c93dfe440f416f8434dfda48b39fa7a6a095d1392a1b11a8affe82eae724a964L103-R124) [[2]](diffhunk://#diff-5e83e6fdc64cc30dc1b8bad942e2fb3423eb8e7d9a4cd1fa06d57801c0bef688L98-R112) [[3]](diffhunk://#diff-5e83e6fdc64cc30dc1b8bad942e2fb3423eb8e7d9a4cd1fa06d57801c0bef688L217-R211)
* The `LLMSession` logic for handling tool calls and resuming generation is refactored to use the streaming API, yielding chunks to the user as they are produced. [[1]](diffhunk://#diff-493e9d9919a9444256385e0d44e2d0cef13668a6bd270949861d46faec333d09L162-L180) [[2]](diffhunk://#diff-493e9d9919a9444256385e0d44e2d0cef13668a6bd270949861d46faec333d09L189-L206) [[3]](diffhunk://#diff-493e9d9919a9444256385e0d44e2d0cef13668a6bd270949861d46faec333d09L33)

### Testing Updates

* The `LLMSessionToolCallingTests` mock client and assertions are updated to use `resumeStream` and track its usage, ensuring the new API is exercised in tests. [[1]](diffhunk://#diff-c68b78e9d06e1ec282c49e5c8bfb04fa3c882f57cb57987f8e2706a5f0bdb629L20-R19) [[2]](diffhunk://#diff-c68b78e9d06e1ec282c49e5c8bfb04fa3c882f57cb57987f8e2706a5f0bdb629L65-R76) [[3]](diffhunk://#diff-c68b78e9d06e1ec282c49e5c8bfb04fa3c882f57cb57987f8e2706a5f0bdb629L108-R112) [[4]](diffhunk://#diff-c68b78e9d06e1ec282c49e5c8bfb04fa3c882f57cb57987f8e2706a5f0bdb629L144-R148) [[5]](diffhunk://#diff-c68b78e9d06e1ec282c49e5c8bfb04fa3c882f57cb57987f8e2706a5f0bdb629L35-R34)

### Minor Improvements

* Minor code cleanups and comments are removed for clarity in several files, including `Sampler.swift` and `LLMSession.swift`. [[1]](diffhunk://#diff-a6f0179b056dbad4c16fbb0b2c8059f24f5890912ac040a7d497376039ae8cfdL16-R16) [[2]](diffhunk://#diff-493e9d9919a9444256385e0d44e2d0cef13668a6bd270949861d46faec333d09L33) [[3]](diffhunk://#diff-493e9d9919a9444256385e0d44e2d0cef13668a6bd270949861d46faec333d09L162-L180)

---

This refactor makes the tool call resumption API more consistent and future-proof, allowing for richer and more flexible streaming interactions with LLMs.