### PR TITLE
Support tool calls for FoundationModelsClient

### DIFF
--- a/Sources/LocalLLMClientCore/LLMClient.swift
+++ b/Sources/LocalLLMClientCore/LLMClient.swift
@@ -123,16 +123,46 @@ public extension LLMClient {
 
 // Extension for default tool calling behavior
 public extension LLMClient where ResponseGenerator == AsyncThrowingStream<StreamingChunk, any Error>, ResumeGenerator == AsyncThrowingStream<StreamingChunk, any Error> {
+    /// Generates tool calls from the given input using default streaming implementation
     func generateToolCalls(from input: LLMInput) async throws -> GeneratedContent {
-        throw LLMError.invalidParameter(reason: "Tool calls are not supported by this LLM client")
+        var text = ""
+        var toolCalls: [LLMToolCall] = []
+
+        for try await content in try await responseStream(from: input) {
+            switch content {
+            case .text(let chunk):
+                text += chunk
+            case .toolCall(let toolCall):
+                toolCalls.append(toolCall)
+            }
+        }
+
+        return GeneratedContent(text: text, toolCalls: toolCalls)
     }
 
+    /// Resumes a conversation with tool outputs
+    ///
+    /// - Parameters:
+    ///   - toolCalls: The tool calls that were made
+    ///   - toolOutputs: The outputs from executing the tools (toolCallID, output)
+    ///   - originalInput: The original input that generated the tool call
+    /// - Returns: The model's response to the tool outputs
+    /// - Throws: An error if text generation fails
     func resumeStream(
         withToolCalls toolCalls: [LLMToolCall],
         toolOutputs: [(String, String)],
         originalInput: LLMInput
     ) async throws -> AsyncThrowingStream<StreamingChunk, any Error> {
-        throw LLMError.invalidParameter(reason: "Tool calls are not supported by this LLM client")
+        guard case let .chat(messages) = originalInput.value else {
+            throw LLMError.invalidParameter(reason: "Original input must be a chat")
+        }
+
+        var updatedMessages = messages
+        for (toolCallID, output) in toolOutputs {
+            updatedMessages.append(.tool(output, toolCallID: toolCallID))
+        }
+
+        return try await responseStream(from: .chat(updatedMessages))
     }
 
     func responseStream(from input: LLMInput) async throws -> AsyncThrowingStream<StreamingChunk, any Error> {

--- a/Sources/LocalLLMClientMLX/MLXClient.swift
+++ b/Sources/LocalLLMClientMLX/MLXClient.swift
@@ -70,48 +70,6 @@ public final actor MLXClient: LLMClient {
         }
     }
     
-    /// Generates tool calls from the given input using default streaming implementation
-    public func generateToolCalls(from input: LLMInput) async throws -> GeneratedContent {
-        var text = ""
-        var toolCalls: [LLMToolCall] = []
-        
-        for try await content in try await responseStream(from: input) {
-            switch content {
-            case .text(let chunk):
-                text += chunk
-            case .toolCall(let toolCall):
-                toolCalls.append(toolCall)
-            }
-        }
-        
-        return GeneratedContent(text: text, toolCalls: toolCalls)
-    }
-    
-    /// Resumes a conversation with tool outputs
-    ///
-    /// - Parameters:
-    ///   - toolCalls: The tool calls that were made
-    ///   - toolOutputs: The outputs from executing the tools (toolCallID, output)
-    ///   - originalInput: The original input that generated the tool call
-    /// - Returns: The model's response to the tool outputs
-    /// - Throws: An error if text generation fails
-    public func resumeStream(
-        withToolCalls toolCalls: [LLMToolCall],
-        toolOutputs: [(String, String)],
-        originalInput: LLMInput
-    ) async throws -> AsyncThrowingStream<StreamingChunk, any Error> {
-        guard case let .chat(messages) = originalInput.value else {
-            throw LLMError.invalidParameter(reason: "Original input must be a chat")
-        }
-
-        var updatedMessages = messages
-        for (toolCallID, output) in toolOutputs {
-            updatedMessages.append(.tool(output, toolCallID: toolCallID))
-        }
-
-        return try await responseStream(from: .chat(updatedMessages))
-    }
-    
     /// Converts tool parameters to MLX format
     func convertParametersToMLXFormat(_ parameters: [String: any Sendable]) -> [ToolParameter] {
         guard let properties = parameters["properties"] as? [String: [String: any Sendable]] else {

--- a/Tests/LocalLLMClientFoundationModelsTests/ModelTests.swift
+++ b/Tests/LocalLLMClientFoundationModelsTests/ModelTests.swift
@@ -1,7 +1,7 @@
 import Testing
 import Foundation
 
-private let disabledTests = ![nil, "FoundationModels"].contains(ProcessInfo.processInfo.environment["GITHUB_ACTIONS_TEST"])
+private let disabledTests = ProcessInfo.processInfo.environment.keys.contains("GITHUB_ACTIONS_TEST")
 
 @Suite(.serialized, .disabled(if: disabledTests))
 struct ModelTests {}


### PR DESCRIPTION
https://github.com/tattn/LocalLLMClient/issues/74

- Support tool calls for FoundationModelsClient
  - LLMSession of FoundationModels hasn't supported tool calls yet.

----
This pull request refactors the tool call handling logic for LLM clients by moving the default implementations of `generateToolCalls` and `resumeStream` into a protocol extension, and updates the `FoundationModelsClient` to support tool integration and error handling. The changes reduce code duplication, improve extensibility, and add better error reporting for unavailable models.

Key changes:

**Refactoring and Code Reuse:**

* Moved default implementations of `generateToolCalls` and `resumeStream` from individual clients (`LlamaClient`, `MLXClient`) into a protocol extension for `LLMClient`, reducing code duplication and centralizing tool call logic. [[1]](diffhunk://#diff-124615213a0998a217e78652931c9bcee3d4761694732bf7990a7674cf6672dcR126-R165) [[2]](diffhunk://#diff-c93dfe440f416f8434dfda48b39fa7a6a095d1392a1b11a8affe82eae724a964L78-L119) [[3]](diffhunk://#diff-5e83e6fdc64cc30dc1b8bad942e2fb3423eb8e7d9a4cd1fa06d57801c0bef688L73-L114)

**Tool Integration:**

* Updated `FoundationModelsClient` to accept a list of tools via its initializer and static factory, allowing tool support to be configured at client creation. [[1]](diffhunk://#diff-58b24ddbc55275e266a2a42fd32f78b6eac7e178c048b155de1731385f68d23fR27-R59) [[2]](diffhunk://#diff-58b24ddbc55275e266a2a42fd32f78b6eac7e178c048b155de1731385f68d23fL156-R197)

**Streaming and Error Handling:**

* Added a `responseStream(from:)` method to `FoundationModelsClient` for streaming both text and tool call responses, and improved error handling by introducing a `FoundationModelsClientError` for unavailable models. [[1]](diffhunk://#diff-58b24ddbc55275e266a2a42fd32f78b6eac7e178c048b155de1731385f68d23fR69-R90) [[2]](diffhunk://#diff-58b24ddbc55275e266a2a42fd32f78b6eac7e178c048b155de1731385f68d23fR109-R115)

These changes make the codebase cleaner, easier to extend, and more robust in handling tool-based interactions and model availability.