### PR TITLE
Add an overloaded mlx method to pass the source directly

### DIFF
--- a/Sources/LocalLLMClientMLX/LLMSession+MLX.swift
+++ b/Sources/LocalLLMClientMLX/LLMSession+MLX.swift
@@ -9,7 +9,18 @@ public extension LLMSession.DownloadModel {
         destination: URL? = nil,
         parameter: MLXClient.Parameter = .default
     ) -> LLMSession.DownloadModel {
-        let source = FileDownloader.Source.huggingFace(id: id, globs: .mlx)
+        .mlx(
+            source: FileDownloader.Source.huggingFace(id: id, globs: .mlx),
+            destination: destination,
+            parameter: parameter
+        )
+    }
+
+    static func mlx(
+        source: FileDownloader.Source,
+        destination: URL? = nil,
+        parameter: MLXClient.Parameter = .default
+    ) -> LLMSession.DownloadModel {
         let rootDestination = destination ?? URL.defaultRootDirectory
         return LLMSession.DownloadModel(
             source: source,


### PR DESCRIPTION
https://github.com/tattn/LocalLLMClient/issues/78
* Add an overloaded mlx method to pass the source directly

---
This pull request refactors the way MLX models are downloaded by introducing a new static `mlx` method, allowing more flexibility in specifying the download source, destination, and parameters.

Enhancements to MLX model downloading:

* Added a new static `mlx` method to `LLMSession.DownloadModel` that accepts a `FileDownloader.Source`, destination URL, and parameters, enabling more flexible model downloads.
* Updated the existing method to delegate to the new `mlx` method, simplifying the code and reducing duplication.