### PR TITLE
Fix: Put text before images in multimodal content array

### DIFF
--- a/Sources/LocalLLMClientLlama/MessageProcessing/MessageTransformer.swift
+++ b/Sources/LocalLLMClientLlama/MessageProcessing/MessageTransformer.swift
@@ -37,9 +37,11 @@ struct StandardMessageTransformer: MessageTransformer {
         }.count
 
         if imageCount > 0 {
-            return (0..<imageCount).map { _ in
-                ["type": "image"] as [String: String]
-            } + [["type": "text", "text": message.content] as [String: String]]
+            // Text must come FIRST, then images - this matches working implementations
+            return [["type": "text", "text": message.content] as [String: String]]
+                + (0..<imageCount).map { _ in
+                    ["type": "image"] as [String: String]
+                }
         } else {
             // Always return array format for consistency with templates
             return [["type": "text", "text": message.content] as [String: String]]


### PR DESCRIPTION
## Summary
Fixes an issue where user prompts were not influencing vision model responses when using multimodal content.

## Problem
The `StandardMessageTransformer.buildContent()` was placing images **before** text in the content array:
```swift
[{"type": "image"}, {"type": "text", "text": "prompt"}]
```

However, vision models (like Qwen2-VL, LLaVA, etc.) expect text to come **first**:
```swift
[{"type": "text", "text": "prompt"}, {"type": "image"}]
```

This matches the working llama.cpp web demo implementation which uses:
```javascript
[{ type: 'text', text: prompt }, { type: 'image_url', ... }]
```

## Symptoms
- User types a specific prompt like "What color is the dominant object?"
- Model responds with generic image description instead of answering the question
- Prompt appears to have no effect on model output

## Fix
Reorder the content array construction to put text first, then images.

## Testing
Tested with Qwen2-VL-2B-Instruct model - prompts now properly influence responses.