### PR TITLE
Fix #93: pin mlx-swift-lm to last pre-v3 commit + declare swift-transformers

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,167 @@
+{
+  "originHash" : "c708fe6da241f5f654a397439002b63f3d60f654ef69d1075851dde3f967586f",
+  "pins" : [
+    {
+      "identity" : "eventsource",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattt/EventSource.git",
+      "state" : {
+        "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "mlx-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ml-explore/mlx-swift",
+      "state" : {
+        "revision" : "61b9e011e09a62b489f6bd647958f1555bdf2896",
+        "version" : "0.31.3"
+      }
+    },
+    {
+      "identity" : "mlx-swift-lm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ml-explore/mlx-swift-lm",
+      "state" : {
+        "revision" : "2a296f145c3129fea4290bb6e4a0a5fb458efa06"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "0fbc8848e389af3bb55c182bc19ca9d5dc2f255b",
+        "version" : "1.4.0"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "1b6b2e274e85105bfa155183145a1dcfd63331f1",
+        "version" : "4.5.0"
+      }
+    },
+    {
+      "identity" : "swift-docc-plugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-plugin",
+      "state" : {
+        "revision" : "e977f65879f82b375a044c8837597f690c067da6",
+        "version" : "1.4.6"
+      }
+    },
+    {
+      "identity" : "swift-docc-symbolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-docc-symbolkit",
+      "state" : {
+        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
+        "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "swift-huggingface",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-huggingface.git",
+      "state" : {
+        "revision" : "b721959445b617d0bf03910b2b4aced345fd93bf",
+        "version" : "0.9.0"
+      }
+    },
+    {
+      "identity" : "swift-jinja",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-jinja",
+      "state" : {
+        "revision" : "62b91283572c80a9d79fe77e2fa344cfd9233cfa",
+        "version" : "2.0.2"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "f71c8d2a5e74a2c6d11a0fbe324774b5d6084237",
+        "version" : "2.99.0"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
+      "state" : {
+        "revision" : "0687f71944021d616d34d922343dcef086855920",
+        "version" : "600.0.1"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
+        "version" : "1.6.4"
+      }
+    },
+    {
+      "identity" : "swift-transformers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-transformers.git",
+      "state" : {
+        "revision" : "58c4bc11963a140358d791f678a60a2745a23146",
+        "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "yyjson",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ibireme/yyjson.git",
+      "state" : {
+        "revision" : "8b4a38dc994a110abaec8a400615567bd996105f",
+        "version" : "0.12.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,24 @@ var packageDependencies: [Package.Dependency] = [
 
 #if os(iOS) || os(macOS)
 packageDependencies.append(contentsOf: [
-    .package(url: "https://github.com/ml-explore/mlx-swift-lm", branch: "main"),
+    // mlx-swift-lm v3 (PR #118 merged 2026-04-01) removed
+    // `loadTokenizer(configuration:hub:)` and reshaped the Hub/Downloader
+    // API; `LocalLLMClientMLX/Context.swift` still uses the old API. Until
+    // the MLX backend is migrated to v3 (`AutoTokenizer.from(directory:)` +
+    // `Downloader`), pin to the last pre-v3 commit so consumers can build.
+    // Tracked in LocalLLMClient#93 — switch back to `branch: "main"` once
+    // Context.swift is migrated.
+    .package(
+        url: "https://github.com/ml-explore/mlx-swift-lm",
+        revision: "2a296f145c3129fea4290bb6e4a0a5fb458efa06"  // 2026-03-27, last pre-v3
+    ),
+    // `Tokenizers` (from swift-transformers) is what `LocalLLMClientMLX`
+    // imports for `any Tokenizer`. Pre-v3 mlx-swift-lm transitively pulled
+    // swift-transformers in, but its Package.swift didn't declare it as a
+    // public re-export, so consumers still need to depend on it directly.
+    // Range matches the pre-v3 mlx-swift-lm transitive pin so SPM resolves.
+    // Bump to `from: "1.3.0"` once Context.swift is migrated to mlx-swift-lm v3.
+    .package(url: "https://github.com/huggingface/swift-transformers.git", "1.2.0"..<"1.3.0"),
     .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.4.0")
 ])
 #endif
@@ -135,6 +152,7 @@ packageTargets.append(contentsOf: [
             "LocalLLMClientCore",
             .product(name: "MLXLLM", package: "mlx-swift-lm"),
             .product(name: "MLXVLM", package: "mlx-swift-lm"),
+            .product(name: "Tokenizers", package: "swift-transformers"),
         ],
     ),
     .testTarget(


### PR DESCRIPTION
Closes #93.

## Problem

`mlx-swift-lm` v3 (PR ml-explore/mlx-swift-lm#118 merged 2026-04-01) reshaped its loading API. Notable removals:

- `loadTokenizer(configuration:hub:)` → moved to `AutoTokenizer.from(directory:)`
- `Hub` / `defaultHubApi` parameter → replaced with a `Downloader`-based `from:` parameter
- `ModelConfiguration.modelDirectory(hub:)` → removed; pass `URL` directly

`LocalLLMClientMLX/Context.swift` (lines 39, 61, 69, 97, 102) still uses the v2 API. Consuming this package against `mlx-swift-lm` `branch: "main"` fails to compile:

```
Sources/LocalLLMClientMLX/Context.swift:39:57: error: 'Tokenizer' is ambiguous for type lookup in this context
Sources/LocalLLMClientMLX/Context.swift:61:89: error: cannot infer contextual base in reference to member 'shared'
Sources/LocalLLMClientMLX/Context.swift:69:69: error: 'Tokenizer' is ambiguous for type lookup in this context
Sources/LocalLLMClientMLX/Context.swift:97:20: error: 'Tokenizer' is ambiguous for type lookup in this context
Sources/LocalLLMClientMLX/Context.swift:102:24: error: 'Tokenizer' is ambiguous for type lookup in this context
```

(The "ambiguous" errors come from both `MLXLMCommon` and `Tokenizers` exposing a `Tokenizer` type once mlx-swift-lm v3 introduces its own.)

## Fix

This PR is a minimum-disruption restoration — it does **not** port `Context.swift` to the v3 API. Instead it pins to the last pre-v3 commit so today's code compiles cleanly:

1. **Pin `mlx-swift-lm`** to commit `2a296f14` (2026-03-27 — last commit before PR #118) via `revision:`. Reproducible (vs `branch:`).
2. **Declare `swift-transformers`** as a direct dependency at `1.2.0..<1.3.0` (the range pre-v3 `mlx-swift-lm` pinned). The `Tokenizers` import in `Context.swift` was satisfied transitively before, but `mlx-swift-lm` never re-exported it, so SPM consumers silently relied on the resolution. Making the dependency explicit removes that fragility.
3. **Add `Tokenizers`** to `LocalLLMClientMLX`'s target dependencies.

## Verification

```
swift build --target LocalLLMClientMLX   # clean
```

(Was failing on main before this PR with the errors above.)

## Follow-up

A future PR should migrate `Context.swift` to the mlx-swift-lm v3 API:

- Replace `loadTokenizer(configuration:hub:)` with `AutoTokenizer.from(directory:)`
- Replace the `hub:` parameter with a `Downloader` (likely `HubClient.default` from `MLXLMHuggingFace`)
- Drop calls to the removed `ModelConfiguration.modelDirectory(hub:)`
- In the same commit:
  - Pinned revision → `branch: "main"`
  - swift-transformers `1.2.0..<1.3.0` → `from: "1.3.0"`

Both pin updates are flagged with comments in `Package.swift` pointing at this migration.

## Downstream

OCCTSwiftPartsAgent and any other downstream consumer that hits this issue can now adopt LocalLLMClient via `revision:` of this PR's branch and unblock their MLX integration paths until the proper migration lands.
