### PR TITLE
Fix release build.

### DIFF
--- a/Example/LocalLLMClientExample/ChatView.swift
+++ b/Example/LocalLLMClientExample/ChatView.swift
@@ -112,6 +112,7 @@ struct ChatBubbleView: View {
     }
 }
 
+#if DEBUG
 #Preview("Text") {
     @Previewable @State var ai: AI = {
         let ai = AI()
@@ -128,6 +129,7 @@ struct ChatBubbleView: View {
     }
     .environment(ai)
 }
+#endif
 
 extension LLMAttachment {
     static let imagePreview = try! Self.image(LLMInputImage(data: .init(contentsOf: URL(string: "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/cats.jpeg")!))!)

--- a/Sources/LocalLLMClientLlama/stb_image.swift
+++ b/Sources/LocalLLMClientLlama/stb_image.swift
@@ -38,7 +38,7 @@ public func stbi_load(_ filename: UnsafePointer<CChar>, _ x: UnsafeMutablePointe
     return rgbBytes
 }
 
-@used
+@_used
 @_silgen_name("stbi_image_free")
 public func stbi_image_free(_ buffer: UnsafeMutableRawPointer) {
     buffer.assumingMemoryBound(to: UInt8.self).deallocate()

--- a/Sources/LocalLLMClientLlama/stb_image.swift
+++ b/Sources/LocalLLMClientLlama/stb_image.swift
@@ -3,7 +3,7 @@
 import Accelerate
 import CoreImage
 
-@used
+@_used
 @_silgen_name("stbi_load_from_memory")
 public func stbi_load_from_memory(_ buffer:  UnsafePointer<UInt8>, _ len: UInt64, _ x: UnsafeMutablePointer<Int32>, _ y: UnsafeMutablePointer<Int32>, _ comp: UnsafeMutablePointer<Int32>, _ req_comp: Int32) -> UnsafeMutableRawPointer? {
     assert(req_comp == 3, "Only RGB format is supported")

--- a/Sources/LocalLLMClientLlama/stb_image.swift
+++ b/Sources/LocalLLMClientLlama/stb_image.swift
@@ -3,8 +3,9 @@
 import Accelerate
 import CoreImage
 
+@used
 @_silgen_name("stbi_load_from_memory")
-func stbi_load_from_memory(_ buffer:  UnsafePointer<UInt8>, _ len: UInt64, _ x: UnsafeMutablePointer<Int32>, _ y: UnsafeMutablePointer<Int32>, _ comp: UnsafeMutablePointer<Int32>, _ req_comp: Int32) -> UnsafeMutableRawPointer? {
+public func stbi_load_from_memory(_ buffer:  UnsafePointer<UInt8>, _ len: UInt64, _ x: UnsafeMutablePointer<Int32>, _ y: UnsafeMutablePointer<Int32>, _ comp: UnsafeMutablePointer<Int32>, _ req_comp: Int32) -> UnsafeMutableRawPointer? {
     assert(req_comp == 3, "Only RGB format is supported")
 
     let data = Data(bytes: buffer, count: Int(len))
@@ -19,8 +20,9 @@ func stbi_load_from_memory(_ buffer:  UnsafePointer<UInt8>, _ len: UInt64, _ x: 
     return rgbBytes
 }
 
+@used
 @_silgen_name("stbi_load")
-func stbi_load(_ filename: UnsafePointer<CChar>, _ x: UnsafeMutablePointer<Int32>, _ y: UnsafeMutablePointer<Int32>, _ comp: UnsafeMutablePointer<Int32>, _ req_comp: Int32) -> UnsafeMutableRawPointer? {
+public func stbi_load(_ filename: UnsafePointer<CChar>, _ x: UnsafeMutablePointer<Int32>, _ y: UnsafeMutablePointer<Int32>, _ comp: UnsafeMutablePointer<Int32>, _ req_comp: Int32) -> UnsafeMutableRawPointer? {
     assert(req_comp == 3, "Only RGB format is supported")
 
     guard let url = URL(string: String(cString: filename)),
@@ -36,8 +38,9 @@ func stbi_load(_ filename: UnsafePointer<CChar>, _ x: UnsafeMutablePointer<Int32
     return rgbBytes
 }
 
+@used
 @_silgen_name("stbi_image_free")
-func stbi_image_free(_ buffer: UnsafeMutableRawPointer) {
+public func stbi_image_free(_ buffer: UnsafeMutableRawPointer) {
     buffer.assumingMemoryBound(to: UInt8.self).deallocate()
 }
 

--- a/Sources/LocalLLMClientLlama/stb_image.swift
+++ b/Sources/LocalLLMClientLlama/stb_image.swift
@@ -20,7 +20,7 @@ public func stbi_load_from_memory(_ buffer:  UnsafePointer<UInt8>, _ len: UInt64
     return rgbBytes
 }
 
-@used
+@_used
 @_silgen_name("stbi_load")
 public func stbi_load(_ filename: UnsafePointer<CChar>, _ x: UnsafeMutablePointer<Int32>, _ y: UnsafeMutablePointer<Int32>, _ comp: UnsafeMutablePointer<Int32>, _ req_comp: Int32) -> UnsafeMutableRawPointer? {
     assert(req_comp == 3, "Only RGB format is supported")


### PR DESCRIPTION
### Motivation:
Unable to build in release mode.
Choose Mac or iOS target -> Edit Scheme -> Build type = Release.

### Linker error:
`Undefined symbol: _stbi_load_from_memory`

Reason:
Compiler strips these symbols. Linker can't find them.

Additional fix:
`#if DEBUG`
over chat view.
